### PR TITLE
Add Challenge auth

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,10 @@ authors = ["Andrew J. Stone <andrew@oxidecomputer.com>"]
 
 [dependencies]
 bitflags = "1.3"
+rand = {version = "0.8", features = ["getrandom"]}
 ring = "0.16.20"
 webpki = "0.22.0"
 
 [dev-dependencies]
+test-utils = { path = "test-utils" }
 rcgen = "0.8.14"

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,19 @@ pub const MAX_CERT_CHAIN_SIZE: usize = 1536;
 // This must be larger than MAX_CERT_CHAIN_SIZE
 pub const TRANSCRIPT_SIZE: usize = 2048;
 
+// The maximum size of a hash in bytes.
+pub const MAX_DIGEST_SIZE: usize = 64;
+
+// The maximum size of a signature in bytes
+pub const MAX_SIGNATURE_SIZE: usize = 128;
+
+// ChallengeAuth responses allow opaque data.
+// This is probably not necessary for most users/transports.
+pub const MAX_OPAQUE_DATA_SIZE: usize = 0;
+
+// The maximum depth of a certificate chain
+pub const MAX_CERT_CHAIN_DEPTH: usize = 6;
+
 pub trait Config {
     type Digest: Digest;
 }

--- a/src/crypto/digest.rs
+++ b/src/crypto/digest.rs
@@ -1,6 +1,7 @@
-use crate::msgs::algorithms::BaseHashAlgo;
 use core::cmp::PartialEq;
 use core::convert::AsRef;
+
+use crate::msgs::algorithms::BaseHashAlgo;
 
 /// A very basic digest trait
 pub trait Digest: AsRef<[u8]> {

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1,1 +1,3 @@
 pub mod digest;
+pub mod pki;
+pub mod signing;

--- a/src/crypto/pki.rs
+++ b/src/crypto/pki.rs
@@ -1,0 +1,261 @@
+use ring::io::der;
+
+use crate::config::MAX_SIGNATURE_SIZE;
+use core::convert::TryFrom;
+
+use crate::msgs::algorithms::BaseAsymAlgo;
+
+#[derive(Debug)]
+pub enum Error {
+    InvalidCert,
+    ValidationFailed,
+}
+
+// TODO: Put this behind a feature flag
+pub fn new_end_entity_cert<'a>(
+    leaf_cert: &'a [u8],
+) -> Result<impl EndEntityCert<'a>, Error> {
+    WebpkiEndEntityCert::new(leaf_cert)
+}
+
+/// An EndEntityCert represents the leaf certificate in a certificate chain.
+///
+/// It can be used to verify that a msg was signed by the certificate's
+/// corresponding private key.
+///
+/// It can also be verfied that an EndEntityCert is valid for a certificate ///
+/// chain given a root certifcate and chain of intermediate certificates where
+/// the first intermediate certificate in the chain is signed by the root
+/// certificate and the last intermediate certificate in the chain has signed
+/// the EndEntity (leaf) certificate.
+///
+///
+/// An EndEntityCert wraps an ASN.1 DER encoded x.509 v3 certificate.
+pub trait EndEntityCert<'a> {
+    fn verify_signature(
+        &self,
+        algorithm: BaseAsymAlgo,
+        msg: &[u8],
+        signature: &[u8],
+    ) -> bool;
+
+    fn verify_chain_of_trust(
+        &self,
+        algorithm: BaseAsymAlgo,
+        intermediate_certs: &[&[u8]],
+        root_cert: &[u8],
+        seconds_since_unix_epoch: u64,
+    ) -> Result<(), Error>;
+}
+
+// We don't support any RSA algorithms via webpki because they are based on
+// Ring which requires using alloc;
+//
+// Note that we map a specific curve to a single hash function, which
+// matches the spirit of TLS 1.3 and also fits the signature sizes expected
+// in the `BaseAsymAlgo` description of the `NEGOTIATE_ALGORITHMS` message.
+pub fn spdm_to_webpki(
+    algo: BaseAsymAlgo,
+) -> &'static webpki::SignatureAlgorithm {
+    match algo {
+        BaseAsymAlgo::ECDSA_ECC_NIST_P256 => &webpki::ECDSA_P256_SHA256,
+        BaseAsymAlgo::ECDSA_ECC_NIST_P384 => &webpki::ECDSA_P384_SHA384,
+        _ => unimplemented!(),
+    }
+}
+
+/// webpki based implementaion of `EndEntityCert`
+///
+/// TODO: put behind a feature flag
+pub struct WebpkiEndEntityCert<'a> {
+    cert: webpki::EndEntityCert<'a>,
+}
+
+impl<'a> WebpkiEndEntityCert<'a> {
+    pub fn new(cert: &'a [u8]) -> Result<WebpkiEndEntityCert<'a>, Error> {
+        let cert = webpki::EndEntityCert::try_from(cert)
+            .map_err(|_| Error::InvalidCert)?;
+        Ok(WebpkiEndEntityCert { cert })
+    }
+}
+
+impl<'a> EndEntityCert<'a> for WebpkiEndEntityCert<'a> {
+    fn verify_signature(
+        &self,
+        algorithm: BaseAsymAlgo,
+        msg: &[u8],
+        signature: &[u8],
+    ) -> bool {
+        let algo = spdm_to_webpki(algorithm);
+        let mut der = [0u8; max_encoded_size()];
+        let size = bin_to_der(signature, &mut der[..]);
+        self.cert.verify_signature(algo, msg, &der[..size]).is_ok()
+    }
+
+    fn verify_chain_of_trust(
+        &self,
+        algorithm: BaseAsymAlgo,
+        intermediate_certs: &[&[u8]],
+        root_cert: &[u8],
+        seconds_since_unix_epoch: u64,
+    ) -> Result<(), Error> {
+        let trust_anchors = [webpki::TrustAnchor::try_from_cert_der(root_cert)
+            .map_err(|_| Error::InvalidCert)?; 1];
+
+        // TODO: Does it matter if we use server or client here?
+        let server_trust_anchors =
+            webpki::TlsServerTrustAnchors(&trust_anchors);
+
+        let time = webpki::Time::from_seconds_since_unix_epoch(
+            seconds_since_unix_epoch,
+        );
+
+        let algo = spdm_to_webpki(algorithm);
+
+        // TODO: Map error types for more info?
+        self.cert
+            .verify_is_valid_tls_server_cert(
+                &[algo],
+                &server_trust_anchors,
+                intermediate_certs,
+                time,
+            )
+            .map_err(|_| Error::ValidationFailed)
+    }
+}
+
+// Convert `r` and `s` values from fixed size big-endian integers where each
+// takes up 1/2 of the `signature` buffer into a ASN.1 DER encoded buffer
+// as described in
+// https://datatracker.ietf.org/doc/html/rfc3279#section-2.2.3.
+//
+// ASN.1 DER encoding for integers is signed, but `r` and `s` must be positive.
+// Therfore, if the first bit of `r` or `s` contains a 1, we must pad it with a
+// zero. Then we DER encode the padded value as an integer.
+//
+// The DER encoded value in ASN.1 types is:
+//
+// Ecdsa-Sig-Value ::= SEQUENCE {
+//     r   INTEGER,
+//     s   INTEGER
+// }
+//
+// This ends up being serialized in Tag-length-value (TLV) form as:
+//
+// 0x30 <s1> 0x02 <s2> <vr> 0x02 <s3> <vs>
+//
+// where:
+//      `0x30` is the tag for a `SEQUENCE`
+//      `<s1>`, `<s2>`,`<s3>` are variably encoded lengths of the next value
+//      `0x02` is the tag for an `INTEGER`
+//      `vr` and `vs` are the DER encoded positive integers for `r` and `s`
+//
+fn bin_to_der(signature: &[u8], out: &mut [u8]) -> usize {
+    let value_size = signature.len() / 2;
+    let r = &signature[..value_size];
+    let s = &signature[value_size..];
+
+    let (r_start, r_len) = get_start_and_length(r);
+    let (s_start, s_len) = get_start_and_length(s);
+
+    // Compute the size of the encoded integer sequence
+    let sig_len = 2 + r_len + s_len + der_length(r_len) + der_length(s_len);
+
+    // Write out the sequence tag and length
+    out[0] = der::Tag::Sequence as u8;
+    let mut written = 1 + write_der_length(&mut out[1..], sig_len);
+
+    // Write r and s
+    written += integer_to_der(&mut out[written..], &r[r_start..]);
+    written += integer_to_der(&mut out[written..], &s[s_start..]);
+
+    written
+}
+
+// Take an integer (`r` or `s`) and return as a pair its start location and its
+// size including any necessary pad bytes.
+fn get_start_and_length(i: &[u8]) -> (usize, usize) {
+    let start = i.iter().position(|b| *b != 0).unwrap();
+    let pad = if i[start] & 0x80 != 0 { 1 } else { 0 };
+    let length = i.len() - start + pad;
+    (start, length)
+}
+
+// Write an integer into a buffer as DER encoded positive integer
+//
+// Return the number of bytes written
+fn integer_to_der(out: &mut [u8], integer: &[u8]) -> usize {
+    let pad = if integer[0] & 0x80 != 0 { 1 } else { 0 };
+    let mut written = 1;
+    out[0] = der::Tag::Integer as u8;
+    written += write_der_length(&mut out[written..], integer.len() + pad);
+    if pad == 1 {
+        out[written] = 0;
+        written += 1;
+    }
+    out[written..][..integer.len()].copy_from_slice(integer);
+    written + integer.len()
+}
+
+// Write out a DER encoded variable length
+//
+// We assume values no larger than 2^16 bytes.
+fn write_der_length(out: &mut [u8], length: usize) -> usize {
+    if length < 128 {
+        out[0] = length as u8;
+        1
+    } else if length < 256 {
+        out[0] = 0x81;
+        out[1] = length as u8;
+        2
+    } else {
+        assert!(length < 65536);
+        let buf = (length as u16).to_be_bytes();
+        out[0] = 0x82;
+        out[1] = buf[0];
+        out[2] = buf[1];
+        3
+    }
+}
+
+// Compute the max DER encoded size of a signature.
+//
+// A signature is made up of two positive integers: `r` and `s`.
+//
+// We assume that all bytes of the signature are used and the high bit is a
+// 1, which induces a padding of a zero byte so we end up with a positive
+// integer.
+//
+// We also assume that the total size of `r` and `s` is less than 2^16 bytes,
+// such that the total size of the variable length encoding needed is 3 bytes.
+#[rustfmt::skip]
+const fn max_encoded_size() -> usize {
+    const TAG_SIZE: usize = 1;
+    let hash_size = MAX_SIGNATURE_SIZE / 2;
+    let size_bytes_needed_per_hash = der_length(hash_size);
+
+    // Tag-length-value (TLV) for the integers
+    let body_size =
+         MAX_SIGNATURE_SIZE // Values of `r` and `s`
+         + 2                // leading 0 pad bytes to make `r` and `s` positive
+         + 2 * TAG_SIZE     // Integer tags
+         + size_bytes_needed_per_hash * 2;
+
+    // Tag-length-value form for the whole signature
+    TAG_SIZE // Sequence tag
+        + der_length(body_size)
+        + body_size
+}
+
+// Return the number of bytes needed to DER encode the length a value.
+// We assume values no larger than 2^16 bytes require encoding.
+const fn der_length(size: usize) -> usize {
+    assert!(size < 65536);
+    if size < 128 {
+        1
+    } else if size < 256 {
+        2
+    } else {
+        3
+    }
+}

--- a/src/crypto/signing.rs
+++ b/src/crypto/signing.rs
@@ -1,0 +1,110 @@
+use core::convert::AsRef;
+
+use ring::signature::{
+    EcdsaKeyPair, EcdsaSigningAlgorithm, ECDSA_P256_SHA256_FIXED_SIGNING,
+    ECDSA_P384_SHA384_FIXED_SIGNING,
+};
+
+use ring::rand::SystemRandom;
+
+use crate::msgs::algorithms::BaseAsymAlgo;
+
+// Opaque error type
+#[derive(Debug)]
+pub struct Error {}
+
+// The simplest possible trait to represent a signature.
+pub trait Signature: AsRef<[u8]> {}
+
+/// Providers implement this trait to generate digital signatures
+pub trait Signer {
+    type Signature: Signature;
+
+    fn sign(&self, msg: &[u8]) -> Result<Self::Signature, Error>;
+}
+
+// Convert a SPDM algorithmn to a Ring algorithm
+//
+// TODO: Put behind feature
+fn spdm_to_ring(algorithm: BaseAsymAlgo) -> &'static EcdsaSigningAlgorithm {
+    match algorithm {
+        BaseAsymAlgo::ECDSA_ECC_NIST_P256 => &ECDSA_P256_SHA256_FIXED_SIGNING,
+        BaseAsymAlgo::ECDSA_ECC_NIST_P384 => &ECDSA_P384_SHA384_FIXED_SIGNING,
+        _ => unimplemented!(),
+    }
+}
+
+/// Take a private key in PKCS#8 v1 format and create a new signer. The signer
+/// key must correspond to the given algorithm.
+///
+/// This is explicitly not part of a trait, as a HW module would not take a
+/// private key. The application level software should call this function.
+///
+// TODO: Use features, as this only supports `ring` now
+pub fn new_signer(
+    algorithm: BaseAsymAlgo,
+    private_key: &[u8],
+) -> Result<RingSigner, Error> {
+    let algorithm = spdm_to_ring(algorithm);
+    RingSigner::new(algorithm, private_key)
+}
+
+/// A signer backed by ring
+///
+// TODO: Put behind a feature
+pub struct RingSigner {
+    key_pair: EcdsaKeyPair,
+    rng: SystemRandom,
+}
+
+impl RingSigner {
+    pub fn new(
+        algorithm: &'static EcdsaSigningAlgorithm,
+        private_key: &[u8],
+    ) -> Result<RingSigner, Error> {
+        let key_pair = EcdsaKeyPair::from_pkcs8(algorithm, private_key)
+            .map_err(|_| Error {})?;
+        Ok(RingSigner { key_pair, rng: SystemRandom::new() })
+    }
+}
+
+impl Signature for ring::signature::Signature {}
+
+impl Signer for RingSigner {
+    type Signature = ring::signature::Signature;
+
+    fn sign(&self, msg: &[u8]) -> Result<Self::Signature, Error> {
+        self.key_pair.sign(&self.rng, msg).map_err(|_| Error {})
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::pki::{new_end_entity_cert, EndEntityCert};
+    use test_utils::certs::*;
+
+    // Sign a message using a private key and verify it using a certificate
+    #[test]
+    fn sign_and_verify() {
+        let algorithm = BaseAsymAlgo::ECDSA_ECC_NIST_P256;
+        let leaf_params = cert_params_ecdsa_p256_sha256(false, "Leaf");
+        let cert = rcgen::Certificate::from_params(leaf_params).unwrap();
+
+        let private_key = cert.serialize_private_key_der();
+        let signer = new_signer(algorithm, &private_key).unwrap();
+
+        let leaf_der = cert.serialize_der().unwrap();
+        let end_entity_cert = new_end_entity_cert(&leaf_der).unwrap();
+
+        let msg = b"hello, hello";
+
+        let signature = signer.sign(msg).unwrap();
+
+        assert!(end_entity_cert.verify_signature(
+            algorithm,
+            msg,
+            signature.as_ref()
+        ));
+    }
+}

--- a/src/msgs/algorithms.rs
+++ b/src/msgs/algorithms.rs
@@ -18,6 +18,21 @@ bitflags! {
    }
 }
 
+impl BaseAsymAlgo {
+    pub fn get_signature_size(&self) -> usize {
+        use BaseAsymAlgo as A;
+        match *self {
+            A::RSASSA_2048 | A::RSAPSS_2048 => 256,
+            A::RSASSA_3072 | A::RSAPSS_3072 => 384,
+            A::ECDSA_ECC_NIST_P256 => 64,
+            A::RSASSA_4096 | A::RSAPSS_4096 => 512,
+            A::ECDSA_ECC_NIST_P384 => 96,
+            A::ECDSA_ECC_NIST_P521 => 132,
+            _ => unreachable!()
+        }
+    }
+}
+
 bitflags! {
     #[derive(Default)]
     pub struct BaseHashAlgo: u32 {
@@ -27,6 +42,18 @@ bitflags! {
         const SHA3_256 = 0x8;
         const SHA3_384 = 0x10;
         const SHA3_512 = 0x20;
+    }
+}
+
+impl BaseHashAlgo {
+    pub fn get_digest_size(&self) -> u8 {
+        use BaseHashAlgo as H;
+        match *self {
+            H::SHA_256 | H::SHA3_256 => 32,
+            H::SHA_384 | H::SHA3_384 => 48,
+            H::SHA_512 | H::SHA3_512 => 64,
+            _ => unreachable!(),
+        }
     }
 }
 
@@ -751,7 +778,6 @@ pub mod tests {
             [AlgorithmResponse::default(); MAX_ALGORITHM_REQUESTS];
         algo_responses(&mut responses);
         let mut msg = algo(responses);
-
 
         // Patch the responses to have more than 1 bit set
         algo_requests(&mut msg.algorithm_responses);

--- a/src/msgs/certificates.rs
+++ b/src/msgs/certificates.rs
@@ -1,3 +1,7 @@
+use core::cmp::PartialEq;
+
+use crate::config::MAX_CERT_CHAIN_DEPTH;
+
 use super::encoding::{ReadError, ReadErrorKind, Reader, WriteError, Writer};
 use super::Msg;
 
@@ -84,10 +88,198 @@ impl<const N: usize> Certificate<N> {
     }
 }
 
+/// Represents a complete certificate chain. This may result from the
+/// concatenation of buffers from multiple `Certificate` messages. For now we
+/// only support retreiving cert chains in a single message.
+///
+/// Certificates inside the cert chain are verified outside of this module.
+///
+/// This corresponds to the "Certificate chain format" table in section 10.6.1
+/// of version 1.1.1 of the SPDM spec
+#[derive(Debug, Clone)]
+pub struct CertificateChain<'a> {
+    pub root_hash: &'a [u8],
+    pub leaf_cert: &'a [u8],
+
+    // The certs are in order from closest to the root to the leaf.
+    // In this implementation we assume that the root certificate is *not*
+    // transmitted via the SPDM protocol, but instead is provisioned out of
+    // band.
+    num_intermediate_certs: u8,
+    intermediate_certs: [&'a [u8]; MAX_CERT_CHAIN_DEPTH],
+}
+
+// We manually implement PartialEq because intermediate_certs is of variable
+// size and may contain garbage from initialization.
+impl<'a> PartialEq for CertificateChain<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        self.root_hash == other.root_hash
+            && self.leaf_cert == other.leaf_cert
+            && self.intermediate_certs() == other.intermediate_certs()
+    }
+}
+
+impl<'a> Eq for CertificateChain<'a> {}
+
+// Indicates that there is no more room for intermediate certs in a
+// `CertificateChain`.
+#[derive(Debug)]
+pub struct Full {}
+
+impl<'a> CertificateChain<'a> {
+    pub fn new(root_hash: &'a [u8], leaf_cert: &'a [u8]) -> Self {
+        CertificateChain {
+            root_hash,
+            leaf_cert,
+
+            // We initialize the array with "default" references, since we need
+            // a slice of slices (`&[&[u8]]`) for use with webpki, and therefore
+            // can't use an `option<&[u8]>`.
+            //
+            // We don't allow direct access to prevent misuse.
+            intermediate_certs: [leaf_cert; MAX_CERT_CHAIN_DEPTH],
+            num_intermediate_certs: 0,
+        }
+    }
+
+    pub fn intermediate_certs(&self) -> &[&[u8]] {
+        &self.intermediate_certs[0..self.num_intermediate_certs as usize]
+    }
+
+    pub fn append_intermediate_cert(
+        &mut self,
+        cert: &'a [u8],
+    ) -> Result<(), Full> {
+        if self.num_intermediate_certs as usize == MAX_CERT_CHAIN_DEPTH {
+            return Err(Full {});
+        }
+        self.intermediate_certs[self.num_intermediate_certs as usize] = cert;
+        self.num_intermediate_certs += 1;
+        Ok(())
+    }
+
+    pub fn write(&self, w: &mut Writer) -> Result<usize, WriteError> {
+        let length = 4
+            + self.root_hash.len()
+            + (0..self.num_intermediate_certs as usize)
+                .fold(0, |acc, i| acc + self.intermediate_certs[i].len())
+            + self.leaf_cert.len();
+        if length > 65535 {
+            // TODO: Return a better indicator of what went wrong?
+            return Err(WriteError::new("CERTFICATE", length));
+        }
+        w.put_u16(length as u16)?;
+        w.put_reserved(2)?;
+        w.extend(self.root_hash)?;
+        for i in 0..self.num_intermediate_certs as usize {
+            w.extend(self.intermediate_certs[i])?;
+        }
+        w.extend(self.leaf_cert)
+    }
+
+    pub fn parse(
+        buf: &'a [u8],
+        digest_size: u8,
+    ) -> Result<CertificateChain<'a>, ReadError> {
+        let mut r = Reader::new("CERTFICATE", buf);
+        let length = r.get_u16()?;
+        if length as usize != buf.len() {
+            return Err(Self::err_unexpected());
+        }
+        r.skip_reserved(2)?;
+        let offset = r.byte_offset();
+        r.skip_ignored(digest_size)?;
+        let root_hash = &buf[offset..offset + digest_size as usize];
+
+        let mut num_intermediate_certs = 0u8;
+        let mut intermediate_certs = [buf; MAX_CERT_CHAIN_DEPTH];
+
+        // parse DER headers of certs
+        let leaf_offset = loop {
+            let offset = r.byte_offset();
+            let (length, header_size) = Self::read_cert_size(&mut r)?;
+            if length > r.remaining() {
+                return Err(Self::err_unexpected());
+            }
+            if length == r.remaining() {
+                // we found the end entity cert
+                break offset;
+            }
+            if num_intermediate_certs as usize == MAX_CERT_CHAIN_DEPTH {
+                return Err(ReadError::new(
+                    "CERTFICATE",
+                    ReadErrorKind::ImplementationLimitReached,
+                ));
+            }
+            let end = offset + length + header_size;
+            intermediate_certs[num_intermediate_certs as usize] =
+                &buf[offset..end];
+            num_intermediate_certs += 1;
+
+            let _ = r.get_slice(length)?;
+        };
+
+        let leaf_cert = &buf[leaf_offset..];
+
+        Ok(CertificateChain {
+            root_hash,
+            num_intermediate_certs,
+            intermediate_certs,
+            leaf_cert,
+        })
+    }
+
+    fn err_unexpected() -> ReadError {
+        return ReadError::new("CERTFICATE", ReadErrorKind::UnexpectedValue);
+    }
+
+    // Read the size of the cert from the DER encoded header along with the
+    // number of bytes read (2 - 4).
+    //
+    // If the high order bit of the first byte is set to zero then the length
+    // is encoded in the seven remaining bits of that byte. Otherwise, those
+    // seven bits represent the number of bytes used to encode the length in big
+    // endian format.
+    fn read_cert_size(r: &mut Reader) -> Result<(usize, usize), ReadError> {
+        // Skip the sequence byte
+        assert_eq!(r.get_byte()?, 0x30);
+
+        let pair = match r.get_byte()? {
+            n if (n & 0x80) == 0 => (n.into(), 2),
+            0x81 => {
+                let n = r.get_byte()?;
+                if n < 128 {
+                    return Err(Self::err_unexpected());
+                }
+                (n.into(), 3)
+            }
+            0x82 => {
+                let high = r.get_byte()? as usize;
+                let low = r.get_byte()? as usize;
+                let n = (high << 8) | low;
+                if n < 256 {
+                    return Err(Self::err_unexpected());
+                }
+                (n.into(), 4)
+            }
+            _ => {
+                return Err(Self::err_unexpected());
+            }
+        };
+        Ok(pair)
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use core::convert::TryFrom;
+    use rcgen;
+    use std::time::SystemTime;
+    use webpki;
+
     use super::super::HEADER_SIZE;
     use super::*;
+    use test_utils::certs::*;
 
     #[test]
     fn get_certificate_round_trip() {
@@ -116,5 +308,120 @@ mod tests {
 
         let msg2 = Certificate::parse_body(&buf[HEADER_SIZE..]).unwrap();
         assert_eq!(msg, msg2);
+    }
+
+    #[test]
+    fn roundtrip_cert_chain_no_intermediate() {
+        let root_params = cert_params_ecdsa_p256_sha256(true, "Root");
+        let root_cert = rcgen::Certificate::from_params(root_params).unwrap();
+        let leaf_params = cert_params_ecdsa_p256_sha256(true, "Leaf");
+        let leaf_cert = rcgen::Certificate::from_params(leaf_params).unwrap();
+        let der = leaf_cert.serialize_der_with_signer(&root_cert).unwrap();
+
+        let fake_hash = [0u8; 32];
+
+        let cert_chain = CertificateChain::new(&fake_hash, &der);
+
+        let mut buf = [0u8; 1024];
+        let mut w = Writer::new("test", &mut buf);
+        let size = cert_chain.write(&mut w).unwrap();
+
+        let digest_size = 32;
+        let cert_chain2 =
+            CertificateChain::parse(&buf[..size], digest_size).unwrap();
+        assert_eq!(cert_chain, cert_chain2);
+    }
+
+    #[test]
+    fn roundtrip_cert_chain_2_intermediates() {
+        let root_params = cert_params_ecdsa_p256_sha256(true, "Root");
+        let root_cert = rcgen::Certificate::from_params(root_params).unwrap();
+        let intermediate1_params =
+            cert_params_ecdsa_p256_sha256(true, "intermediate1");
+        let intermediate1_cert =
+            rcgen::Certificate::from_params(intermediate1_params).unwrap();
+        let intermediate2_params =
+            cert_params_ecdsa_p256_sha256(true, "intermediate2");
+        let intermediate2_cert =
+            rcgen::Certificate::from_params(intermediate2_params).unwrap();
+        let leaf_params = cert_params_ecdsa_p256_sha256(false, "Leaf");
+        let leaf_cert = rcgen::Certificate::from_params(leaf_params).unwrap();
+
+        let der_inter1 =
+            intermediate1_cert.serialize_der_with_signer(&root_cert).unwrap();
+        let der_inter2 = intermediate2_cert
+            .serialize_der_with_signer(&intermediate1_cert)
+            .unwrap();
+        let der_leaf =
+            leaf_cert.serialize_der_with_signer(&intermediate2_cert).unwrap();
+
+        let fake_hash = [0u8; 32];
+
+        let mut cert_chain = CertificateChain::new(&fake_hash, &der_leaf);
+        cert_chain.append_intermediate_cert(&der_inter1).unwrap();
+        cert_chain.append_intermediate_cert(&der_inter2).unwrap();
+
+        let mut buf = [0u8; 2048];
+        let mut w = Writer::new("test", &mut buf);
+        let size = cert_chain.write(&mut w).unwrap();
+
+        let digest_size = 32;
+        let cert_chain2 =
+            CertificateChain::parse(&buf[..size], digest_size).unwrap();
+        assert_eq!(cert_chain, cert_chain2);
+    }
+
+    // This test is basically ensuring that `rcgen` generated cert chains can be parsed
+    // and verified by `webpki`. This is a useful test for correctness, since
+    // both crates are written by independent authors. It serves mostly as an
+    // example of how to use webpki with DER encoded cert chains.
+    #[test]
+    fn example_webpki_verify_cert_chain() {
+        let root_params = cert_params_ecdsa_p256_sha256(true, "Root");
+        let root_cert = rcgen::Certificate::from_params(root_params).unwrap();
+        let intermediate1_params =
+            cert_params_ecdsa_p256_sha256(true, "intermediate1");
+        let intermediate1_cert =
+            rcgen::Certificate::from_params(intermediate1_params).unwrap();
+        let intermediate2_params =
+            cert_params_ecdsa_p256_sha256(true, "intermediate2");
+        let intermediate2_cert =
+            rcgen::Certificate::from_params(intermediate2_params).unwrap();
+        let leaf_params = cert_params_ecdsa_p256_sha256(false, "Leaf");
+        let leaf_cert = rcgen::Certificate::from_params(leaf_params).unwrap();
+
+        let der_root = root_cert.serialize_der().unwrap();
+        let der_inter1 =
+            intermediate1_cert.serialize_der_with_signer(&root_cert).unwrap();
+        let der_inter2 = intermediate2_cert
+            .serialize_der_with_signer(&intermediate1_cert)
+            .unwrap();
+        let der_leaf =
+            leaf_cert.serialize_der_with_signer(&intermediate2_cert).unwrap();
+
+        let intermediate_certs = vec![&der_inter1[..], &der_inter2[..]];
+        let trust_anchors =
+            vec![webpki::TrustAnchor::try_from_cert_der(&der_root).unwrap()];
+        let server_trust_anchors =
+            webpki::TlsServerTrustAnchors(&trust_anchors);
+
+        let end_entity_cert =
+            webpki::EndEntityCert::try_from(&der_leaf[..]).unwrap();
+
+        let seconds = SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 10000;
+        let time = webpki::Time::from_seconds_since_unix_epoch(seconds);
+
+        end_entity_cert
+            .verify_is_valid_tls_server_cert(
+                &[&webpki::ECDSA_P256_SHA256],
+                &server_trust_anchors,
+                &intermediate_certs[..],
+                time,
+            )
+            .unwrap();
     }
 }

--- a/src/msgs/challenge.rs
+++ b/src/msgs/challenge.rs
@@ -1,0 +1,297 @@
+use core::cmp::PartialEq;
+use core::convert::{TryFrom, TryInto};
+
+use rand::{rngs::OsRng, RngCore};
+
+use super::encoding::{ReadError, ReadErrorKind, Reader, WriteError, Writer};
+use super::Msg;
+use crate::config::{
+    MAX_DIGEST_SIZE, MAX_OPAQUE_DATA_SIZE, MAX_SIGNATURE_SIZE,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum MeasurementHashType {
+    None = 0x0,
+    Tcb = 0x1,
+    All = 0xFF,
+}
+
+impl TryFrom<u8> for MeasurementHashType {
+    type Error = ReadError;
+
+    fn try_from(val: u8) -> Result<Self, Self::Error> {
+        match val {
+            0x0 => Ok(MeasurementHashType::None),
+            0x1 => Ok(MeasurementHashType::Tcb),
+            0xFF => Ok(MeasurementHashType::All),
+            _ => {
+                Err(ReadError::new("CHALLENGE", ReadErrorKind::UnexpectedValue))
+            }
+        }
+    }
+}
+
+pub fn nonce() -> [u8; 32] {
+    let mut nonce = [0u8; 32];
+    OsRng.fill_bytes(&mut nonce);
+    nonce
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Challenge {
+    pub slot: u8,
+    pub measurement_hash_type: MeasurementHashType,
+    pub nonce: [u8; 32],
+}
+
+impl Challenge {
+    pub fn new(slot: u8, measurement_hash_type: MeasurementHashType) -> Self {
+        let nonce = nonce();
+        Challenge { slot, measurement_hash_type, nonce }
+    }
+}
+
+impl Msg for Challenge {
+    const NAME: &'static str = "CHALLENGE";
+    const SPDM_VERSION: u8 = 0x11;
+    const SPDM_CODE: u8 = 0x83;
+
+    fn write_body(&self, w: &mut Writer) -> Result<usize, WriteError> {
+        w.put(self.slot)?;
+        w.put(self.measurement_hash_type as u8)?;
+        w.extend(&self.nonce)
+    }
+}
+
+impl Challenge {
+    pub fn parse_body(buf: &[u8]) -> Result<Challenge, ReadError> {
+        let mut r = Reader::new(Self::NAME, buf);
+        let slot = r.get_byte()?;
+        let measurement_hash_type = r.get_byte()?.try_into()?;
+        let mut nonce = [0u8; 32];
+        nonce.copy_from_slice(r.get_slice(32)?);
+        Ok(Challenge { slot, measurement_hash_type, nonce })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ChallengeAuth {
+    // Set to 0xF if the responder's public key was pre-provisioned on the
+    // requester.
+    pub slot: u8,
+    pub slot_mask: u8,
+    pub use_mutual_auth: bool,
+    pub digest_size: u8,
+    pub cert_chain_hash: [u8; MAX_DIGEST_SIZE],
+    pub nonce: [u8; 32],
+    pub measurement_summary_hash: [u8; MAX_DIGEST_SIZE],
+    pub opaque_data_len: u16,
+    pub opaque_data: [u8; MAX_OPAQUE_DATA_SIZE],
+    pub signature_size: usize,
+    pub signature: [u8; MAX_SIGNATURE_SIZE],
+}
+
+// We can't derive PartialEq because hashes and signature buffers may only be
+// partially full.
+impl PartialEq for ChallengeAuth {
+    fn eq(&self, other: &Self) -> bool {
+        self.slot == other.slot
+            && self.slot_mask == other.slot_mask
+            && self.digest_size == other.digest_size
+            && self.cert_chain_hash[..self.digest_size as usize]
+                == other.cert_chain_hash[..other.digest_size as usize]
+            && self.nonce == other.nonce
+            && self.measurement_summary_hash[..self.digest_size as usize]
+                == other.measurement_summary_hash[..other.digest_size as usize]
+            && self.opaque_data_len == other.opaque_data_len
+            && self.opaque_data[..self.opaque_data_len as usize]
+                == other.opaque_data[..other.opaque_data_len as usize]
+            && self.signature_size == other.signature_size
+            && self.signature[..self.signature_size as usize]
+                == other.signature[..other.signature_size as usize]
+    }
+}
+
+impl Eq for ChallengeAuth {}
+
+impl Msg for ChallengeAuth {
+    const NAME: &'static str = "CHALLENGE_AUTH";
+    const SPDM_VERSION: u8 = 0x11;
+    const SPDM_CODE: u8 = 0x03;
+
+    fn write_body(&self, w: &mut Writer) -> Result<usize, WriteError> {
+        assert!(self.slot < 8);
+        if self.use_mutual_auth {
+            w.put(self.slot & (1 << 7))?;
+        } else {
+            w.put(self.slot)?;
+        }
+        w.put(self.slot_mask)?;
+        w.extend(&self.cert_chain_hash[..self.digest_size as usize])?;
+        w.extend(&self.nonce)?;
+        w.extend(&self.measurement_summary_hash[..self.digest_size as usize])?;
+        w.put_u16(self.opaque_data_len)?;
+        if self.opaque_data_len > 0 {
+            w.extend(&self.opaque_data[..self.opaque_data_len as usize])?;
+        }
+        w.extend(&self.signature[..self.signature_size as usize])
+    }
+}
+
+impl ChallengeAuth {
+    pub fn new(
+        slot: u8,
+        slot_mask: u8,
+        use_mutual_auth: bool,
+        cert_chain_digest: &[u8],
+        nonce: [u8; 32],
+        measurement_summary_digest: &[u8],
+        opaque: &[u8],
+        sig: &[u8],
+    ) -> ChallengeAuth {
+        let digest_size = cert_chain_digest.len();
+
+        let mut cert_chain_hash = [0u8; MAX_DIGEST_SIZE];
+        cert_chain_hash[..digest_size]
+            .copy_from_slice(cert_chain_digest.as_ref());
+
+        let mut measurement_summary_hash = [0u8; MAX_DIGEST_SIZE];
+        measurement_summary_hash[..digest_size]
+            .copy_from_slice(measurement_summary_digest.as_ref());
+
+        let opaque_data_len = opaque.len();
+        let mut opaque_data = [0u8; MAX_OPAQUE_DATA_SIZE];
+        opaque_data[..opaque_data_len].copy_from_slice(opaque);
+
+        let signature_size = sig.len();
+        let mut signature = [0u8; MAX_SIGNATURE_SIZE];
+        signature[..signature_size].copy_from_slice(sig);
+
+        ChallengeAuth {
+            slot,
+            slot_mask,
+            use_mutual_auth,
+            digest_size: u8::try_from(digest_size).unwrap(),
+            cert_chain_hash,
+            nonce,
+            measurement_summary_hash,
+            opaque_data_len: u16::try_from(opaque_data_len).unwrap(),
+            opaque_data,
+            signature_size,
+            signature,
+        }
+    }
+
+    pub fn cert_chain_hash(&self) -> &[u8] {
+        &self.cert_chain_hash[..self.digest_size as usize]
+    }
+
+    pub fn measurement_summary_hash(&self) -> &[u8] {
+        &self.measurement_summary_hash[..self.digest_size as usize]
+    }
+
+    pub fn opaque_date(&self) -> &[u8] {
+        &self.opaque_data[..self.opaque_data_len as usize]
+    }
+
+    pub fn signature(&self) -> &[u8] {
+        &self.signature[..self.signature_size]
+    }
+
+    pub fn parse_body(
+        buf: &[u8],
+        digest_size: u8,
+        signature_size: usize,
+    ) -> Result<ChallengeAuth, ReadError> {
+        let mut r = Reader::new(Self::NAME, buf);
+        let slot = r.get_bits(4)?;
+        let _ = r.get_bits(3)?;
+        let use_mutual_auth = r.get_bit()? == 1;
+        let slot_mask = r.get_byte()?;
+
+        let mut cert_chain_hash = [0u8; MAX_DIGEST_SIZE];
+        cert_chain_hash[..digest_size as usize]
+            .copy_from_slice(r.get_slice(digest_size as usize)?);
+
+        let mut nonce = [0u8; 32];
+        nonce.copy_from_slice(r.get_slice(32)?);
+
+        let mut measurement_summary_hash = [0u8; MAX_DIGEST_SIZE];
+        measurement_summary_hash[..digest_size as usize]
+            .copy_from_slice(r.get_slice(digest_size as usize)?);
+
+        let opaque_data_len = r.get_u16()?;
+        if opaque_data_len as usize > MAX_OPAQUE_DATA_SIZE {
+            return Err(ReadError::new(
+                Self::NAME,
+                ReadErrorKind::ImplementationLimitReached,
+            ));
+        }
+        let mut opaque_data = [0u8; MAX_OPAQUE_DATA_SIZE];
+        opaque_data[..opaque_data_len as usize]
+            .copy_from_slice(r.get_slice(opaque_data_len as usize)?);
+
+        let mut signature = [0u8; MAX_SIGNATURE_SIZE];
+        signature[..signature_size as usize]
+            .copy_from_slice(r.get_slice(signature_size as usize)?);
+
+        Ok(ChallengeAuth {
+            slot,
+            use_mutual_auth,
+            slot_mask,
+            digest_size,
+            cert_chain_hash,
+            nonce,
+            measurement_summary_hash,
+            opaque_data_len,
+            opaque_data,
+            signature_size,
+            signature,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::HEADER_SIZE;
+    use super::*;
+
+    #[test]
+    fn round_trip_challenge() {
+        let c = Challenge::new(0, MeasurementHashType::Tcb);
+        let mut buf = [0u8; 64];
+        let _ = c.write(&mut buf).unwrap();
+        let c2 = Challenge::parse_body(&buf[HEADER_SIZE..]).unwrap();
+        assert_eq!(c, c2);
+    }
+
+    #[test]
+    fn round_trip_challenge_auth() {
+        let digest_size = 32;
+        let signature_size = 64;
+        let c = ChallengeAuth {
+            slot: 0,
+            use_mutual_auth: false,
+            slot_mask: 0x1,
+            digest_size,
+            cert_chain_hash: [9u8; MAX_DIGEST_SIZE],
+            nonce: [0x13; 32],
+            measurement_summary_hash: [7u8; MAX_DIGEST_SIZE],
+            opaque_data_len: 0,
+            opaque_data: [0u8; 0],
+            signature_size,
+            signature: [1u8; MAX_SIGNATURE_SIZE],
+        };
+        let mut buf = [0u8; 256];
+        let _ = c.write(&mut buf).unwrap();
+        let c2 = ChallengeAuth::parse_body(
+            &buf[HEADER_SIZE..],
+            digest_size,
+            signature_size,
+        )
+        .unwrap();
+
+        assert_eq!(c, c2);
+    }
+}

--- a/src/msgs/digest.rs
+++ b/src/msgs/digest.rs
@@ -1,5 +1,7 @@
 use core::cmp::PartialEq;
 
+use crate::config::MAX_DIGEST_SIZE;
+
 use super::encoding::{ReadError, Reader, WriteError, Writer};
 use super::Msg;
 
@@ -42,7 +44,7 @@ impl DigestBuf {
 
 impl Default for DigestBuf {
     fn default() -> Self {
-        DigestBuf { buf: [0; 64] }
+        DigestBuf { buf: [0; MAX_DIGEST_SIZE] }
     }
 }
 

--- a/src/msgs/encoding.rs
+++ b/src/msgs/encoding.rs
@@ -279,6 +279,10 @@ impl<'a> Reader<'a> {
         Ok(u32::from_le_bytes(*buf))
     }
 
+    pub fn byte_offset(&self) -> usize {
+        self.byte_offset
+    }
+
     pub fn remaining(&self) -> usize {
         self.buf.len() - self.byte_offset
     }

--- a/src/msgs/mod.rs
+++ b/src/msgs/mod.rs
@@ -4,6 +4,7 @@ pub mod encoding;
 pub mod version;
 pub mod digest;
 pub mod certificates;
+pub mod challenge;
 
 use encoding::Writer;
 pub use encoding::{ReadError, ReadErrorKind, WriteError};
@@ -11,7 +12,8 @@ pub use version::{GetVersion, Version, VersionEntry};
 pub use capabilities::{GetCapabilities, Capabilities};
 pub use algorithms::{NegotiateAlgorithms, Algorithms};
 pub use digest::{GetDigests, Digests};
-pub use certificates::{GetCertificate, Certificate};
+pub use certificates::{GetCertificate, Certificate, CertificateChain};
+pub use challenge::{Challenge, ChallengeAuth, MeasurementHashType};
 
 pub const HEADER_SIZE: usize = 2;
 

--- a/src/requester.rs
+++ b/src/requester.rs
@@ -12,6 +12,7 @@ pub mod algorithms;
 pub mod capabilities;
 pub mod id_auth;
 pub mod version;
+pub mod challenge;
 
 mod error;
 

--- a/src/requester/challenge.rs
+++ b/src/requester/challenge.rs
@@ -1,0 +1,154 @@
+use core::convert::From;
+
+use super::{expect, id_auth, RequesterError};
+use crate::config::{Config, MAX_CERT_CHAIN_SIZE};
+use crate::crypto::{
+    digest::Digest,
+    pki::{new_end_entity_cert, EndEntityCert},
+};
+use crate::msgs::capabilities::{ReqFlags, RspFlags};
+use crate::msgs::{
+    Algorithms, CertificateChain, Challenge, ChallengeAuth,
+    MeasurementHashType, Msg, VersionEntry, HEADER_SIZE,
+};
+
+use crate::Transcript;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Transition {
+    Placeholder,
+}
+
+/// Perform challenge-response authentication using the certificate chain
+/// received from the responder.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct State {
+    pub version: VersionEntry,
+    pub requester_ct_exponent: u8,
+    pub requester_cap: ReqFlags,
+    pub responder_ct_exponent: u8,
+    pub responder_cap: RspFlags,
+    pub algorithms: Algorithms,
+    pub cert_slot: u8,
+    pub cert_chain: [u8; MAX_CERT_CHAIN_SIZE],
+    pub cert_chain_size: u16,
+    pub nonce: [u8; 32],
+}
+
+impl From<id_auth::State> for State {
+    fn from(s: id_auth::State) -> Self {
+        State {
+            version: s.version,
+            requester_ct_exponent: s.requester_ct_exponent,
+            requester_cap: s.requester_cap,
+            responder_ct_exponent: s.responder_ct_exponent,
+            responder_cap: s.responder_cap,
+            algorithms: s.algorithms,
+            cert_slot: s.cert_chain.as_ref().unwrap().slot,
+            cert_chain: s.cert_chain.as_ref().unwrap().cert_chain,
+            cert_chain_size: s.cert_chain.unwrap().portion_length,
+            nonce: [0u8; 32],
+        }
+    }
+}
+
+impl State {
+    /// Write a CHALLENGE msg to the buffer.
+    pub fn write_challenge_msg(
+        &mut self,
+        measurement_hash_type: MeasurementHashType,
+        buf: &mut [u8],
+        transcript: &mut Transcript,
+    ) -> Result<usize, RequesterError> {
+        let challenge = Challenge::new(self.cert_slot, measurement_hash_type);
+        self.nonce = challenge.nonce;
+        let size = challenge.write(buf).map_err(|e| RequesterError::from(e))?;
+        transcript.extend(&buf[..size])?;
+        Ok(size)
+    }
+
+    pub fn handle_msg<C: Config>(
+        self,
+        buf: &[u8],
+        transcript: &mut Transcript,
+        root_cert: &[u8],
+        seconds_since_unix_epoch: u64,
+    ) -> Result<Transition, RequesterError> {
+        expect::<ChallengeAuth>(buf)?;
+        let hash_algo = self.algorithms.base_hash_algo_selected;
+
+        let digest_size = hash_algo.get_digest_size();
+        let signature_size =
+            self.algorithms.base_asym_algo_selected.get_signature_size();
+        let rsp = ChallengeAuth::parse_body(
+            &buf[HEADER_SIZE..],
+            digest_size,
+            signature_size,
+        )?;
+        if rsp.slot != self.cert_slot {
+            return Err(RequesterError::BadChallengeAuth);
+        }
+        // Provisioned certs don't need retrieval
+        if (rsp.slot != 0x0F) && (rsp.slot_mask != (1 << rsp.slot)) {
+            return Err(RequesterError::BadChallengeAuth);
+        }
+
+        // TODO: Handle pre-provisioned certs
+        let digest = C::Digest::hash(
+            hash_algo,
+            &self.cert_chain[..self.cert_chain_size as usize],
+        );
+
+        if rsp.cert_chain_hash() != digest.as_ref() {
+            return Err(RequesterError::BadChallengeAuth);
+        }
+
+        // TODO: Do something with returned measurements
+        // TODO: Do something with opaque data
+
+        // Generate M2 as in the SPDM spec by extending the transcript with the
+        // ChallengeAuth response without the signature.
+        let sig_start = buf.len() - signature_size;
+        transcript.extend(&buf[..sig_start])?;
+        let m2_hash = C::Digest::hash(hash_algo, transcript.get());
+
+        self.verify_cert_chain_and_signature(
+            digest_size,
+            m2_hash.as_ref(),
+            rsp.signature(),
+            root_cert,
+            seconds_since_unix_epoch,
+        )
+    }
+
+    fn verify_cert_chain_and_signature(
+        &self,
+        digest_size: u8,
+        m2_hash: &[u8],
+        signature: &[u8],
+        root_cert: &[u8],
+        seconds_since_unix_epoch: u64,
+    ) -> Result<Transition, RequesterError> {
+        let cert_chain_buf = &self.cert_chain[..self.cert_chain_size as usize];
+        let cert_chain = CertificateChain::parse(cert_chain_buf, digest_size)?;
+
+        let end_entity_cert = new_end_entity_cert(cert_chain.leaf_cert)?;
+
+        end_entity_cert.verify_chain_of_trust(
+            self.algorithms.base_asym_algo_selected,
+            cert_chain.intermediate_certs(),
+            root_cert,
+            seconds_since_unix_epoch,
+        )?;
+
+        if !end_entity_cert.verify_signature(
+            self.algorithms.base_asym_algo_selected,
+            m2_hash,
+            signature,
+        ) {
+            return Err(RequesterError::BadChallengeAuth);
+        }
+
+        Ok(Transition::Placeholder)
+    }
+}

--- a/src/requester/error.rs
+++ b/src/requester/error.rs
@@ -1,3 +1,4 @@
+use crate::crypto::pki;
 use crate::msgs::{ReadError, Version, WriteError};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -14,7 +15,13 @@ pub enum RequesterError {
     NoSupportedVersions { received: Version },
 
     // The responder chose an algorithm that was not a requester option
-    SelectedAlgorithmNotRequested
+    SelectedAlgorithmNotRequested,
+
+    // The challenge auth response was invalid
+    BadChallengeAuth,
+
+    // A certificate could not be parsed properly
+    InvalidCert,
 }
 
 impl From<WriteError> for RequesterError {
@@ -26,5 +33,11 @@ impl From<WriteError> for RequesterError {
 impl From<ReadError> for RequesterError {
     fn from(e: ReadError) -> Self {
         RequesterError::Read(e)
+    }
+}
+
+impl From<pki::Error> for RequesterError {
+    fn from(_: pki::Error) -> Self {
+        RequesterError::InvalidCert
     }
 }

--- a/src/responder.rs
+++ b/src/responder.rs
@@ -12,6 +12,7 @@ pub mod algorithms;
 pub mod capabilities;
 pub mod id_auth;
 pub mod version;
+pub mod challenge;
 
 mod error;
 

--- a/src/responder/challenge.rs
+++ b/src/responder/challenge.rs
@@ -1,0 +1,122 @@
+use core::convert::From;
+
+use super::{capabilities, expect, id_auth, ResponderError};
+
+use crate::config::{
+    Config, MAX_CERT_CHAIN_SIZE, MAX_DIGEST_SIZE, MAX_SIGNATURE_SIZE, NUM_SLOTS,
+};
+use crate::crypto::{digest::Digest, signing::Signer};
+use crate::msgs::capabilities::{ReqFlags, RspFlags};
+use crate::msgs::{
+    challenge::nonce, encoding::Writer, Algorithms, CertificateChain,
+    Challenge, ChallengeAuth, Msg, HEADER_SIZE,
+};
+use crate::{reset_on_get_version, Transcript};
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Transition {
+    Capabilities(capabilities::State),
+    Placeholder,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+pub struct State {
+    pub requester_ct_exponent: u8,
+    pub requester_cap: ReqFlags,
+    pub responder_ct_exponent: u8,
+    pub responder_cap: RspFlags,
+    pub algorithms: Algorithms,
+}
+
+impl From<id_auth::State> for State {
+    fn from(s: id_auth::State) -> Self {
+        State {
+            requester_ct_exponent: s.requester_ct_exponent,
+            requester_cap: s.requester_cap,
+            responder_ct_exponent: s.responder_ct_exponent,
+            responder_cap: s.responder_cap,
+            algorithms: s.algorithms,
+        }
+    }
+}
+
+impl State {
+    pub fn handle_msg<'a, C: Config, S: Signer>(
+        self,
+        cert_chains: &[Option<CertificateChain<'a>>; NUM_SLOTS],
+        signer: &S,
+        req: &[u8],
+        rsp: &mut [u8],
+        transcript: &mut Transcript,
+    ) -> Result<(usize, Transition), ResponderError> {
+        reset_on_get_version!(req, rsp, transcript);
+        expect::<Challenge>(req)?;
+        let digest_size =
+            self.algorithms.base_hash_algo_selected.get_digest_size();
+        let signature_size =
+            self.algorithms.base_asym_algo_selected.get_signature_size();
+
+        let req_msg = Challenge::parse_body(&req[HEADER_SIZE..])?;
+
+        let cert_chain_digest =
+            if let Some(Some(chain)) = cert_chains.get(req_msg.slot as usize) {
+                let mut buf = [0u8; MAX_CERT_CHAIN_SIZE];
+                let mut w = Writer::new("CERTIFICATE_CHAIN", &mut buf);
+                let size = chain.write(&mut w)?;
+                C::Digest::hash(
+                    self.algorithms.base_hash_algo_selected,
+                    &buf[..size],
+                )
+            } else {
+                return Err(ResponderError::InvalidSlot);
+            };
+
+        let use_mutual_auth =
+            self.requester_cap.contains(ReqFlags::MUT_AUTH_CAP)
+                && self.responder_cap.contains(RspFlags::MUT_AUTH_CAP);
+
+        // TODO: Actually return measurement hashes if requested
+        let measurement_summary_hash = [0u8; MAX_DIGEST_SIZE];
+
+        transcript.extend(req)?;
+
+        // Build the M1 transcript according to the SPDM spec.
+        //
+        // We need to extend the transcript with the serialized ChallengeAuth
+        // message, but excluding the signature. We therefore use a placeholder
+        // signature, serialize, extend the transcript, construct the real
+        // signature, and overwrite the dummy signature in the serialized
+        // message.
+        let dummy_sig = [0u8; MAX_SIGNATURE_SIZE];
+
+        let auth = ChallengeAuth::new(
+            req_msg.slot,
+            id_auth::create_slot_mask(cert_chains),
+            use_mutual_auth,
+            cert_chain_digest.as_ref(),
+            nonce(),
+            &measurement_summary_hash[..digest_size as usize],
+            &[],
+            &dummy_sig[..signature_size],
+        );
+
+        let size = auth.write(rsp)?;
+
+        let sig_start = size - signature_size;
+        transcript.extend(&rsp[..sig_start])?;
+
+        let m1_hash = C::Digest::hash(
+            self.algorithms.base_hash_algo_selected,
+            transcript.get(),
+        );
+
+        let signature = signer
+            .sign(m1_hash.as_ref())
+            .map_err(|_| ResponderError::SigningFailed)?;
+
+        // Attach the real signature to the CHALLENGE_AUTH message
+        rsp[sig_start..size].copy_from_slice(signature.as_ref());
+
+        Ok((size, Transition::Placeholder))
+    }
+}

--- a/src/responder/error.rs
+++ b/src/responder/error.rs
@@ -7,6 +7,12 @@ pub enum ResponderError {
 
     // `got` is the code. TODO: Try to map this to a message name?
     UnexpectedMsg { expected: &'static str, got: u8 },
+
+    // A challenge was sent with a slot that does not contain a cert
+    InvalidSlot,
+
+    // For some reason signing failed. This could be caused by a HW failure.
+    SigningFailed
 }
 
 impl From<WriteError> for ResponderError {

--- a/test-utils/.gitignore
+++ b/test-utils/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "test-utils"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rcgen = "0.8.14"

--- a/test-utils/src/certs.rs
+++ b/test-utils/src/certs.rs
@@ -1,0 +1,83 @@
+use rcgen::{
+    date_time_ymd, BasicConstraints, CertificateParams, DistinguishedName,
+    DnType, ExtendedKeyUsagePurpose, IsCa, KeyIdMethod, KeyUsagePurpose,
+    PKCS_ECDSA_P256_SHA256,
+};
+
+pub fn distinguished_name(cn: &str) -> DistinguishedName {
+    let mut dn = DistinguishedName::new();
+    dn.push(DnType::OrganizationName, "Oxide");
+    dn.push(DnType::CommonName, cn);
+    dn.push(DnType::OrganizationalUnitName, "Test");
+    dn
+}
+
+pub fn ca_key_usages() -> Vec<KeyUsagePurpose> {
+    use rcgen::KeyUsagePurpose as P;
+    vec![
+        P::DigitalSignature,
+        P::ContentCommitment,
+        P::KeyEncipherment,
+        P::DataEncipherment,
+        P::KeyAgreement,
+        P::KeyCertSign,
+        P::CrlSign,
+    ]
+}
+
+pub fn leaf_key_usages() -> Vec<KeyUsagePurpose> {
+    use rcgen::KeyUsagePurpose as P;
+    vec![P::DigitalSignature, P::ContentCommitment, P::KeyEncipherment]
+}
+
+pub fn ca_extended_key_usages() -> Vec<ExtendedKeyUsagePurpose> {
+    use rcgen::ExtendedKeyUsagePurpose as P;
+    vec![P::ServerAuth, P::ClientAuth]
+}
+
+pub fn leaf_extended_key_usages() -> Vec<ExtendedKeyUsagePurpose> {
+    use rcgen::ExtendedKeyUsagePurpose as P;
+    vec![P::ServerAuth, P::ClientAuth, P::OcspSigning]
+}
+
+pub fn cert_params_ecdsa_p256_sha256(
+    is_ca: bool,
+    cn: &str,
+) -> CertificateParams {
+    let key_usages = if is_ca { ca_key_usages() } else { leaf_key_usages() };
+
+    let extended_key_usages = if is_ca {
+        ca_extended_key_usages()
+    } else {
+        leaf_extended_key_usages()
+    };
+
+    let is_ca = if is_ca {
+        IsCa::Ca(BasicConstraints::Unconstrained)
+    } else {
+        IsCa::SelfSignedOnly
+    };
+
+    // Slightly modified from the example in the DMTF spec
+    let subject_alt_name =
+        "otherName:1.3.6.1.4.1.412.274.1;UTF8STRING:OXIDE:COMPUTER:1";
+
+    let mut params = CertificateParams::new(vec![subject_alt_name.to_string()]);
+
+    params.alg = &PKCS_ECDSA_P256_SHA256;
+    params.not_before = date_time_ymd(2021, 10, 27);
+    params.not_after = date_time_ymd(3000, 1, 1);
+    params.serial_number = Some(1);
+    params.subject_alt_names = vec![];
+    params.distinguished_name = distinguished_name(cn);
+    params.is_ca = is_ca;
+    params.key_usages = key_usages;
+    params.extended_key_usages = extended_key_usages;
+    params.name_constraints = None;
+    params.custom_extensions = vec![];
+    params.key_pair = None;
+    params.use_authority_key_identifier_extension = false;
+    params.key_identifier_method = KeyIdMethod::Sha256;
+
+    params
+}

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod certs;

--- a/tests/certs.rs
+++ b/tests/certs.rs
@@ -1,86 +1,9 @@
-use rcgen::{
-    date_time_ymd, BasicConstraints, Certificate, CertificateParams,
-    DistinguishedName, DnType, ExtendedKeyUsagePurpose, IsCa, KeyIdMethod,
-    KeyUsagePurpose, PKCS_ECDSA_P256_SHA256,
-};
+extern crate test_utils;
 
-pub fn distinguished_name(cn: &str) -> DistinguishedName {
-    let mut dn = DistinguishedName::new();
-    dn.push(DnType::OrganizationName, "Oxide");
-    dn.push(DnType::CommonName, cn);
-    dn.push(DnType::OrganizationalUnitName, "Test");
-    dn
-}
+use rcgen::Certificate;
 
-pub fn ca_key_usages() -> Vec<KeyUsagePurpose> {
-    use rcgen::KeyUsagePurpose as P;
-    vec![
-        P::DigitalSignature,
-        P::ContentCommitment,
-        P::KeyEncipherment,
-        P::DataEncipherment,
-        P::KeyAgreement,
-        P::KeyCertSign,
-        P::CrlSign,
-    ]
-}
 
-pub fn leaf_key_usages() -> Vec<KeyUsagePurpose> {
-    use rcgen::KeyUsagePurpose as P;
-    vec![P::DigitalSignature, P::ContentCommitment, P::KeyEncipherment]
-}
-
-pub fn ca_extended_key_usages() -> Vec<ExtendedKeyUsagePurpose> {
-    use rcgen::ExtendedKeyUsagePurpose as P;
-    vec![P::ServerAuth, P::ClientAuth]
-}
-
-pub fn leaf_extended_key_usages() -> Vec<ExtendedKeyUsagePurpose> {
-    use rcgen::ExtendedKeyUsagePurpose as P;
-    vec![P::ServerAuth, P::ClientAuth, P::OcspSigning]
-}
-
-pub fn cert_params_ecdsa_p256_sha256(
-    is_ca: bool,
-    cn: &str,
-) -> CertificateParams {
-    let key_usages = if is_ca { ca_key_usages() } else { leaf_key_usages() };
-
-    let extended_key_usages = if is_ca {
-        ca_extended_key_usages()
-    } else {
-        leaf_extended_key_usages()
-    };
-
-    let is_ca = if is_ca {
-        IsCa::Ca(BasicConstraints::Unconstrained)
-    } else {
-        IsCa::SelfSignedOnly
-    };
-
-    // Slightly modified from the example in the DMTF spec
-    let subject_alt_name =
-        "otherName:1.3.6.1.4.1.412.274.1;UTF8STRING:OXIDE:COMPUTER:1";
-
-    let mut params = CertificateParams::new(vec![subject_alt_name.to_string()]);
-
-    params.alg = &PKCS_ECDSA_P256_SHA256;
-    params.not_before = date_time_ymd(2021, 10, 27);
-    params.not_after = date_time_ymd(3000, 1, 1);
-    params.serial_number = Some(1);
-    params.subject_alt_names = vec![];
-    params.distinguished_name = distinguished_name(cn);
-    params.is_ca = is_ca;
-    params.key_usages = key_usages;
-    params.extended_key_usages = extended_key_usages;
-    params.name_constraints = None;
-    params.custom_extensions = vec![];
-    params.key_pair = None;
-    params.use_authority_key_identifier_extension = false;
-    params.key_identifier_method = KeyIdMethod::Sha256;
-
-    params
-}
+use test_utils::certs::*;
 
 #[test]
 fn gen_certs() {


### PR DESCRIPTION
This is a WIP for supporting the challenge authentication part of the SPDM spec.

PKI related functionality based on
[webpki](https://github.com/briansmith/webpki) is used to validate received
certificates and verify signed messages in the requester. An `EndEntityCert`
trait is used to abstract the underlying PKI mechanism. Although, currently,
there is only a single concrete type (`WebpkiEndEntityCert`), it is anticipated
that there will be more. Due to the lack of Generic Associated Types (GATs), in
stable rust, the strategy of selecting a concrete PKI type via the `Config`
type, as used with `Digest`, was made damn near impossible. This is primarily
due to the lifetime parameter of `EndEntityCert`. Therefore construction of the
concrete type is done via a function, `new_end_entity_cert`, that returns the
proper concrete type. A feature will be added to allow users to select the
proper pki type at compile time. As more crypto types will probably borrow data,
it is likely that the `Config` type will be removed altogether in the future and
`Digest` will use the same pattern here. Note that, this is not really a
problem, as in many cases only a limited set of implementations will
compile.

While `webpki` supports RSA, it only does so via `alloc`, as it utilizes the
ring implementation. In order to make all code in this crate `no_std`, only 2
ECDSA algorithms are supported.

Due to the fact that all of the crypto in this crate is going to be configured
via feature flags, the set of supported algorithms should be generated at build
time for the user, or at least made available in an easy to use manner. The user
may choose to further restrict algorithms beyond what the underlying platform is
capable of and we should allow this. This is just a note for the future, as it
is not going to be done in this PR.

A new `test-utils` crate was added to this repository in order to facilitate
sharing code between integration and unit tests. All the certificate generation
test code based around rcgen was moved in there.

The following checklist indicates completion of major items required for
challenge authentication.

- [x] CHALLENGE and CHALLENGE_AUTH messages
- [x] PKI support for validating certificate chains and verifying signatures
- [x] Signing support for creating signatures (for use by responder)
- [x] Requester support
- [x] Responder support
- [x] End-to-end tests
- [x] Add CHALLENGE and CHALLENGE_AUTH messages to transcript (msg to be signed/verified)