### PR TITLE
Return slices instead of sizes from req/rsp write methods

### DIFF
--- a/src/requester/algorithms.rs
+++ b/src/requester/algorithms.rs
@@ -41,16 +41,16 @@ impl From<capabilities::State> for State {
 impl State {
     /// Serialize a NEGOTIATE_ALGORITHMS request and append it to the
     /// transcript
-    pub fn write_msg(
+    pub fn write_msg<'a>(
         &mut self,
         msg: NegotiateAlgorithms,
-        buf: &mut [u8],
+        buf: &'a mut [u8],
         transcript: &mut Transcript,
-    ) -> Result<usize, RequesterError> {
+    ) -> Result<&'a [u8], RequesterError> {
         let size = msg.write(buf)?;
         self.negotiate_algorithms = Some(msg);
         transcript.extend(&buf[..size])?;
-        Ok(size)
+        Ok(&buf[..size])
     }
 
     /// Only `Algorithms` messsages are acceptable here.

--- a/src/requester/capabilities.rs
+++ b/src/requester/capabilities.rs
@@ -25,17 +25,17 @@ impl State {
     }
 
     /// Write the `msg` into `buf` and record it in `transcript`.
-    pub fn write_msg(
+    pub fn write_msg<'a>(
         &mut self,
         msg: &GetCapabilities,
-        buf: &mut [u8],
+        buf: &'a mut [u8],
         transcript: &mut Transcript,
-    ) -> Result<usize, RequesterError> {
+    ) -> Result<&'a [u8], RequesterError> {
         let size = msg.write(buf)?;
         transcript.extend(&buf[..size])?;
         self.requester_ct_exponent = Some(msg.ct_exponent);
         self.requester_cap = Some(msg.flags);
-        Ok(size)
+        Ok(&buf[..size])
     }
 
     /// Only `Capabilities` messages are acceptable here.

--- a/src/requester/challenge.rs
+++ b/src/requester/challenge.rs
@@ -58,17 +58,17 @@ impl From<id_auth::State> for State {
 
 impl State {
     /// Write a CHALLENGE msg to the buffer, and append it to the transcript.
-    pub fn write_challenge_msg(
+    pub fn write_challenge_msg<'a>(
         &mut self,
         measurement_hash_type: MeasurementHashType,
-        buf: &mut [u8],
+        buf: &'a mut [u8],
         transcript: &mut Transcript,
-    ) -> Result<usize, RequesterError> {
+    ) -> Result<&'a [u8], RequesterError> {
         let challenge = Challenge::new(self.cert_slot, measurement_hash_type);
         self.nonce = challenge.nonce;
         let size = challenge.write(buf).map_err(|e| RequesterError::from(e))?;
         transcript.extend(&buf[..size])?;
-        Ok(size)
+        Ok(&buf[..size])
     }
 
     /// Process a received responder message.

--- a/src/requester/id_auth.rs
+++ b/src/requester/id_auth.rs
@@ -63,14 +63,14 @@ impl State {
     /// TODO: We can probably shrink the transcript to the size of a hash at
     /// this point, since we know the hashing algorithm and can just maintain an
     /// incremental hash. For now, we just continue appending the raw data.
-    pub fn write_get_digests_msg(
+    pub fn write_get_digests_msg<'a>(
         &mut self,
-        buf: &mut [u8],
+        buf: &'a mut [u8],
         transcript: &mut Transcript,
-    ) -> Result<usize, RequesterError> {
+    ) -> Result<&'a [u8], RequesterError> {
         let size = GetDigests {}.write(buf)?;
         transcript.extend(&buf[..size])?;
-        Ok(size)
+        Ok(&buf[..size])
     }
 
     /// Handle a DIGESTS msg.
@@ -94,12 +94,12 @@ impl State {
 
     /// Write a GET_CERTIFICATE msg to the buffer and record it in the
     /// transcript.
-    pub fn write_get_certificate_msg(
+    pub fn write_get_certificate_msg<'a>(
         &mut self,
         slot: u8,
-        buf: &mut [u8],
+        buf: &'a mut [u8],
         transcript: &mut Transcript,
-    ) -> Result<usize, RequesterError> {
+    ) -> Result<&'a [u8], RequesterError> {
         assert!(MAX_CERT_CHAIN_SIZE < 65536);
         assert!((slot as usize) < NUM_SLOTS);
         // TODO: Allow retrieiving cert chains from offsets. We assume for now
@@ -111,7 +111,7 @@ impl State {
         };
         let size = msg.write(buf)?;
         transcript.extend(&buf[..size])?;
-        Ok(size)
+        Ok(&buf[..size])
     }
 
     // Handle a CERTFICATE msg.

--- a/src/requester/version.rs
+++ b/src/requester/version.rs
@@ -11,17 +11,17 @@ pub struct State {}
 
 impl State {
     /// Serialize a get version message into `buf` and append it to `transcript`
-    pub fn write_get_version(
+    pub fn write_get_version<'a>(
         &self,
-        buf: &mut [u8],
+        buf: &'a mut [u8],
         transcript: &mut Transcript,
-    ) -> Result<usize, RequesterError> {
+    ) -> Result<&'a [u8], RequesterError> {
         let size = GetVersion {}.write(buf)?;
 
         // A GetVersion msg always resets the state of the protocol.
         transcript.clear();
         transcript.extend(&buf[..size])?;
-        Ok(size)
+        Ok(&buf[..size])
     }
 
     // Only Version messages are acceptable here.

--- a/src/responder.rs
+++ b/src/responder.rs
@@ -42,10 +42,10 @@ macro_rules! reset_on_get_version {
         match GetVersion::parse_header($req) {
             Ok(true) => {
                 // Go back to the beginning!
-                let (size, cap_state) =
+                let (data, cap_state) =
                     version::State {}.handle_msg($req, $rsp, $transcript)?;
 
-                return Ok((size, Transition::Capabilities(cap_state)));
+                return Ok((data, Transition::Capabilities(cap_state)));
             }
             Err(e) => return Err(e.into()),
             _ => (),

--- a/src/responder/algorithms.rs
+++ b/src/responder/algorithms.rs
@@ -40,12 +40,12 @@ impl State {
     /// Handle a message from a requester
     ///
     /// Only GetVersion and NegotiateAlgorithms messages are valid here.
-    pub fn handle_msg(
+    pub fn handle_msg<'a>(
         mut self,
         req: &[u8],
-        rsp: &mut [u8],
+        rsp: &'a mut [u8],
         transcript: &mut Transcript,
-    ) -> Result<(usize, Transition), ResponderError> {
+    ) -> Result<(&'a [u8], Transition), ResponderError> {
         reset_on_get_version!(req, rsp, transcript);
         expect::<NegotiateAlgorithms>(req)?;
 
@@ -57,7 +57,7 @@ impl State {
         transcript.extend(&rsp[..size])?;
         self.algorithms = Some(algorithms);
 
-        Ok((size, Transition::IdAuth(self.into())))
+        Ok((&rsp[..size], Transition::IdAuth(self.into())))
     }
 
     // We use the simplest mechanism possible here and just choose the first set

--- a/src/responder/capabilities.rs
+++ b/src/responder/capabilities.rs
@@ -35,13 +35,13 @@ impl State {
     /// Only GetVersion and GetCapabilities messages are valid here.
     ///
     /// The caller passes in the set of supported capabilities
-    pub fn handle_msg(
+    pub fn handle_msg<'a>(
         mut self,
         supported: Capabilities,
         req: &[u8],
-        rsp: &mut [u8],
+        rsp: &'a mut [u8],
         transcript: &mut Transcript,
-    ) -> Result<(usize, Transition), ResponderError> {
+    ) -> Result<(&'a [u8], Transition), ResponderError> {
         reset_on_get_version!(req, rsp, transcript);
         expect::<GetCapabilities>(req)?;
 
@@ -55,6 +55,6 @@ impl State {
         self.responder_ct_exponent = Some(supported.ct_exponent);
         self.responder_cap = Some(supported.flags);
 
-        Ok((size, Transition::Algorithms(self.into())))
+        Ok((&rsp[..size], Transition::Algorithms(self.into())))
     }
 }

--- a/src/responder/challenge.rs
+++ b/src/responder/challenge.rs
@@ -49,14 +49,14 @@ impl State {
     /// Handle a message from a requester
     ///
     /// Only CHALLENGE and GET_VERSION msgs are allowed here.
-    pub fn handle_msg<'a, C: Config, S: Signer>(
+    pub fn handle_msg<'a, 'b, C: Config, S: Signer>(
         self,
         cert_chains: &[Option<CertificateChain<'a>>; NUM_SLOTS],
         signer: &S,
         req: &[u8],
-        rsp: &mut [u8],
+        rsp: &'b mut [u8],
         transcript: &mut Transcript,
-    ) -> Result<(usize, Transition), ResponderError> {
+    ) -> Result<(&'b [u8], Transition), ResponderError> {
         reset_on_get_version!(req, rsp, transcript);
         expect::<Challenge>(req)?;
         let digest_size =
@@ -125,6 +125,6 @@ impl State {
         // Attach the real signature to the CHALLENGE_AUTH message
         rsp[sig_start..size].copy_from_slice(signature.as_ref());
 
-        Ok((size, Transition::Placeholder))
+        Ok((&rsp[..size], Transition::Placeholder))
     }
 }

--- a/src/responder/version.rs
+++ b/src/responder/version.rs
@@ -10,12 +10,12 @@ pub struct State {}
 
 impl State {
     /// Handle the initial message from a SPDM requester: GET_VERSION
-    pub fn handle_msg(
+    pub fn handle_msg<'a>(
         self,
         req: &[u8],
-        rsp: &mut [u8],
+        rsp: &'a mut [u8],
         transcript: &mut Transcript,
-    ) -> Result<(usize, capabilities::State), ResponderError> {
+    ) -> Result<(&'a [u8], capabilities::State), ResponderError> {
         match GetVersion::parse_header(req) {
             Ok(true) => self.handle_get_version(req, rsp, transcript),
             Ok(false) => Err(ResponderError::UnexpectedMsg {
@@ -26,12 +26,12 @@ impl State {
         }
     }
 
-    fn handle_get_version(
+    fn handle_get_version<'a>(
         self,
         req: &[u8],
-        rsp: &mut [u8],
+        rsp: &'a mut [u8],
         transcript: &mut Transcript,
-    ) -> Result<(usize, capabilities::State), ResponderError> {
+    ) -> Result<(&'a [u8], capabilities::State), ResponderError> {
         let _ = GetVersion::parse_body(&req[HEADER_SIZE..])?;
 
         // A GetVersion msg always resets the state of the protocol
@@ -41,6 +41,6 @@ impl State {
         let size = Version::default().write(rsp)?;
         transcript.extend(&rsp[..size])?;
 
-        Ok((size, capabilities::State::new()))
+        Ok((&rsp[..size], capabilities::State::new()))
     }
 }


### PR DESCRIPTION
This makes the API a bit safer and more ergonomic.