### PR TITLE
Enhance the ergonomics of the Responder

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -137,7 +137,7 @@ fn max_signature_size(algos: &Vec<String>) -> Result<usize, SpdmConfigError> {
 fn validate_capabilities(caps: &Vec<String>) -> Result<(), SpdmConfigError> {
     for cap in caps {
         match cap.as_str() {
-            "CERT_CAP" | "CHALLENGE_CAP" | "ENCRYPT_CAP" | "MAC_CAP"
+            "CERT_CAP" | "CHAL_CAP" | "ENCRYPT_CAP" | "MAC_CAP"
             | "MUT_AUTH_CAP" | "KEY_EX_CAP" | "KEY_UPD_CAP" => (),
             x => {
                 return Err(SpdmConfigError::InvalidCapability(x.into()));

--- a/spdm-config.toml
+++ b/spdm-config.toml
@@ -1,6 +1,6 @@
 # This file contains an example configuration.
 version = 0x11
-capabilities = ["CERT_CAP", "CHALLENGE_CAP", "ENCRYPT_CAP",  "MAC_CAP", "MUT_AUTH_CAP", "KEY_EX_CAP", "KEY_UPD_CAP"]
+capabilities = ["CERT_CAP", "CHAL_CAP", "ENCRYPT_CAP",  "MAC_CAP", "MUT_AUTH_CAP", "KEY_EX_CAP", "KEY_UPD_CAP"]
 
 [cert_chains]
 num_slots = 1

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -18,3 +18,7 @@
 pub mod digest;
 pub mod pki;
 pub mod signing;
+mod slot;
+
+pub use signing::Signer;
+pub use slot::FilledSlot;

--- a/src/crypto/slot.rs
+++ b/src/crypto/slot.rs
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Code for a wrapper around a SPDM certificate slot
+
+use crate::crypto::signing::Signer;
+use crate::msgs::algorithms::{BaseAsymAlgo, BaseHashAlgo};
+use crate::msgs::CertificateChain;
+
+/// A FilledSlot is a wrapper around a SPDM certificate slot that represents a given
+/// asymmetric key pair and associated certificate chain.
+///
+/// A `Signer` is included because each platform using SPDM may have a different
+/// mechanism for management of private keys and signing. These mechanisms may
+/// include trusted hardware that never reveals the private key. We therefore
+/// bundle a Signer, that is expected to be constructed by the user of this library
+/// for a given slot..
+///
+/// TODO: Right now, the types of algorithms are encoded as SPDM specific base
+/// algorithms. However, it's likely that we will support only a subset of base
+/// algorithms, as well as potentially other algorithms. Maybe we should have a
+/// global enum consisting of all supported algorithms for all platforms that
+/// are then used throughout this library rather than the SPDM types. We would
+/// then map this algorithm to the appropriate underlying base or extended SPDM
+/// algorithm as necessary.
+/// Tracked in https://github.com/oxidecomputer/spdm/issues/24
+pub struct FilledSlot<'a, S: Signer> {
+    pub signing_algorithm: BaseAsymAlgo,
+    pub hash_algorithm: BaseHashAlgo,
+    pub cert_chain: CertificateChain<'a>,
+    pub signer: S,
+}

--- a/src/msgs/capabilities.rs
+++ b/src/msgs/capabilities.rs
@@ -6,6 +6,7 @@ use super::encoding::{ReadError, ReadErrorKind, Reader, WriteError, Writer};
 use super::Msg;
 
 use bitflags::bitflags;
+use core::str::FromStr;
 
 bitflags! {
     /// The Capabilities defined by the requester
@@ -24,6 +25,37 @@ bitflags! {
         const KEY_UPD_CAP = 0b0100_0000_0000_0000;
         const HANDSHAKE_IN_THE_CLEAR_CAP = 0b1000_0000_0000_0000;
         const PUB_KEY_ID_CAP = 0b0000_0001_0000_0000_0000_0000;
+    }
+}
+
+// We only allow strings for fields we want the user to configure, excluding
+// things like `PSK_CAP_MASK`.
+impl FromStr for ReqFlags {
+    type Err = ReadError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let flag = match s {
+            "CERT_CAP" => ReqFlags::CERT_CAP,
+            "CHAL_CAP" => ReqFlags::CHAL_CAP,
+            "ENCRYPT_CAP" => ReqFlags::ENCRYPT_CAP,
+            "MAC_CAP" => ReqFlags::MAC_CAP,
+            "MUT_AUTH_CAP" => ReqFlags::MUT_AUTH_CAP,
+            "KEY_EX_CAP" => ReqFlags::KEY_EX_CAP,
+            "PSK_CAP" => ReqFlags::PSK_CAP,
+            "ENCAP_CAP" => ReqFlags::ENCAP_CAP,
+            "HBEAT_CAP" => ReqFlags::HBEAT_CAP,
+            "KEY_UPD_CAP" => ReqFlags::KEY_UPD_CAP,
+            "HANDSHAKE_IN_THE_CLEAR_CAP" => {
+                ReqFlags::HANDSHAKE_IN_THE_CLEAR_CAP
+            }
+            "PUB_KEY_ID_CAP" => ReqFlags::PUB_KEY_ID_CAP,
+            _ => {
+                return Err(ReadError::new(
+                    "CAPABILITIES",
+                    ReadErrorKind::UnexpectedValue,
+                ))
+            }
+        };
+        Ok(flag)
     }
 }
 
@@ -83,6 +115,39 @@ bitflags! {
         const KEY_UPD_CAP = 0b0100_0000_0000_0000;
         const HANDSHAKE_IN_THE_CLEAR_CAP = 0b1000_0000_0000_0000;
         const PUB_KEY_ID_CAP = 0b0000_0001_0000_0000_0000_0000;
+    }
+}
+
+// We only allow strings for fields we want the user to configure, excluding
+// things like `PSK_CAP_MASK`.impl FromStr for RspFlags {
+impl FromStr for RspFlags {
+    type Err = ReadError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let flag = match s {
+            "CACHE_CAP" => RspFlags::CACHE_CAP,
+            "CERT_CAP" => RspFlags::CERT_CAP,
+            "CHAL_CAP" => RspFlags::CHAL_CAP,
+            "MEAS_FRESH_CAP" => RspFlags::MEAS_FRESH_CAP,
+            "ENCRYPT_CAP" => RspFlags::ENCRYPT_CAP,
+            "MAC_CAP" => RspFlags::MAC_CAP,
+            "MUT_AUTH_CAP" => RspFlags::MUT_AUTH_CAP,
+            "KEY_EX_CAP" => RspFlags::KEY_EX_CAP,
+            "PSK_CAP" => RspFlags::PSK_CAP,
+            "ENCAP_CAP" => RspFlags::ENCAP_CAP,
+            "HBEAT_CAP" => RspFlags::HBEAT_CAP,
+            "KEY_UPD_CAP" => RspFlags::KEY_UPD_CAP,
+            "HANDSHAKE_IN_THE_CLEAR_CAP" => {
+                RspFlags::HANDSHAKE_IN_THE_CLEAR_CAP
+            }
+            "PUB_KEY_ID_CAP" => RspFlags::PUB_KEY_ID_CAP,
+            _ => {
+                return Err(ReadError::new(
+                    "CAPABILITIES",
+                    ReadErrorKind::UnexpectedValue,
+                ))
+            }
+        };
+        Ok(flag)
     }
 }
 

--- a/src/msgs/mod.rs
+++ b/src/msgs/mod.rs
@@ -19,7 +19,7 @@ pub mod certificates;
 pub mod challenge;
 pub mod digest;
 pub mod encoding;
-pub mod error;
+mod error;
 pub mod version;
 
 pub use algorithms::{Algorithms, NegotiateAlgorithms};
@@ -29,6 +29,7 @@ pub use challenge::{Challenge, ChallengeAuth, MeasurementHashType};
 pub use digest::{Digests, GetDigests};
 use encoding::Writer;
 pub use encoding::{ReadError, ReadErrorKind, WriteError};
+pub use error::Error;
 pub use version::{GetVersion, Version, VersionEntry};
 
 pub const HEADER_SIZE: usize = 2;

--- a/src/responder.rs
+++ b/src/responder.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-//! A responder follows the typestate pattern
+//! A responder follows the typestate pattern internally
 //! <https://cliffle.com/blog/rust-typestate/>
 //!
 //!
@@ -20,12 +20,209 @@ pub mod version;
 
 mod error;
 
-use crate::msgs::Msg;
+use crate::config;
+use crate::crypto::{FilledSlot, Signer};
+use crate::msgs::{self, CertificateChain, Msg};
+use crate::Transcript;
 pub use error::ResponderError;
 
-/// Enter the first state of the responder state machine, the 'Version' state
-pub fn start() -> version::State {
-    version::State {}
+use core::convert::From;
+
+/// `AllStates` is a container for all the states in a responder.
+///
+/// This library follows a typestate pattern, where each state has a specific
+/// API and is only accessible one at a time. However, this is a bit cumbersome
+/// to use for a consumer as it consists of taking `self` by value and returning
+/// the next state. Furthermore, since SPDM is a fairly complicated protocol,
+/// using this pattern means that a user of the protocol must look up the
+/// states of the protocol and figure out how they fit together to use them,
+/// even when the states are driven by messages, and potential errors, which the
+/// user does not control.
+///
+/// Such an architecture means that this message handling and state transition
+/// code must be duplicated at each consumer, rather than written once. We
+/// elminate this duplication and provide roughly the same level of type safety
+/// by only implementing state transitions between states directly in the states
+/// themselves, and then putting the resulting output state into a global state
+/// enum, `AllStates`. We then provide a wrapper `Responder` API around
+/// `AllStates` that a user can consume without having to know all the internal
+/// details of the SPDM protocol.
+pub enum AllStates {
+    // A special state that indicates the responder has terminated and the
+    // transport should close its "connection".
+    Error,
+    Version(version::State),
+    Capabilities(capabilities::State),
+    Algorithms(algorithms::State),
+    IdAuth(id_auth::State),
+    Challenge(challenge::State),
+}
+
+impl From<version::State> for AllStates {
+    fn from(state: version::State) -> AllStates {
+        AllStates::Version(state)
+    }
+}
+
+impl From<capabilities::State> for AllStates {
+    fn from(state: capabilities::State) -> AllStates {
+        AllStates::Capabilities(state)
+    }
+}
+
+impl From<algorithms::State> for AllStates {
+    fn from(state: algorithms::State) -> AllStates {
+        AllStates::Algorithms(state)
+    }
+}
+
+impl From<id_auth::State> for AllStates {
+    fn from(state: id_auth::State) -> AllStates {
+        AllStates::IdAuth(state)
+    }
+}
+
+impl From<challenge::State> for AllStates {
+    fn from(state: challenge::State) -> AllStates {
+        AllStates::Challenge(state)
+    }
+}
+
+// TODO: This whole things should probably move to config generation...
+// We would then just abort if the parsing fails
+fn config_to_capabilities_msg() -> Result<msgs::Capabilities, ResponderError> {
+    let mut flags = msgs::capabilities::RspFlags::default();
+    for s in config::CAPABILITIES {
+        flags |= s.parse()?;
+    }
+    Ok(msgs::Capabilities {
+        // TODO: Don't hardcode this - take it from config
+        // See https://github.com/oxidecomputer/spdm/issues/23
+        ct_exponent: 12,
+        flags,
+    })
+}
+
+impl AllStates {
+    fn handle<'a, 'b, S: Signer>(
+        self,
+        req: &[u8],
+        rsp: &'a mut [u8],
+        transcript: &mut Transcript,
+        slots: &'b [Option<FilledSlot<'b, S>>; config::NUM_SLOTS],
+    ) -> (&'a [u8], AllStates, Result<(), ResponderError>) {
+        let res = match self {
+            AllStates::Version(state) => state.handle_msg(req, rsp, transcript),
+            AllStates::Capabilities(state) => state.handle_msg(
+                // This is a programmer error, but one we may want to
+                // catch immediately at startup.
+                // TODO: Move the unwrap earlier to config generation?
+                // Ideally we could do this in build.rs, but that gets hairy...
+                config_to_capabilities_msg().unwrap(),
+                req,
+                rsp,
+                transcript,
+            ),
+            AllStates::Algorithms(state) => {
+                state.handle_msg(req, rsp, transcript)
+            }
+            AllStates::IdAuth(state) => {
+                let mut cert_chains: [Option<CertificateChain<'b>>;
+                    config::NUM_SLOTS] = [None; config::NUM_SLOTS];
+                for i in 0..slots.len() {
+                    cert_chains[i] =
+                        slots[i].as_ref().map(|s| s.cert_chain.clone());
+                }
+                state.handle_msg(&cert_chains, req, rsp, transcript)
+            }
+            AllStates::Challenge(state) => {
+                state.handle_msg(slots, req, rsp, transcript)
+            }
+            _ => unimplemented!(),
+        };
+        match res {
+            Ok((size, state)) => (&rsp[..size], state, Ok(())),
+            Err(responder_err) => {
+                // Write an error message into `rsp` and return it along with
+                // the error.
+                let err_msg: msgs::Error = (&responder_err).into();
+
+                // If we fail writing the error, just return the empty slice.
+                match err_msg.write(rsp) {
+                    Ok(size) => {
+                        (&rsp[..size], AllStates::Error, Err(responder_err))
+                    }
+                    Err(_) => {
+                        (&rsp[0..0], AllStates::Error, Err(responder_err))
+                    }
+                }
+            }
+        }
+    }
+
+    // Return the name of the current state
+    pub fn name(&self) -> &'static str {
+        match self {
+            AllStates::Error => "Error",
+            AllStates::Version(_) => "Version",
+            AllStates::Capabilities(_) => "Capabilities",
+            AllStates::Algorithms(_) => "Algorithms",
+            AllStates::IdAuth(_) => "IdAuth",
+            AllStates::Challenge(_) => "Challenge",
+        }
+    }
+}
+
+/// A wrapper around the Responder state machine states contained in
+/// `AllStates`.
+pub struct Responder<'a, S: Signer> {
+    slots: [Option<FilledSlot<'a, S>>; config::NUM_SLOTS],
+    transcript: Transcript,
+    // This Option allows us to move between states at runtime, without having
+    // to take self by value.
+    state: Option<AllStates>,
+}
+
+impl<'a, S: Signer> Responder<'a, S> {
+    pub fn new(
+        slots: [Option<FilledSlot<'a, S>>; config::NUM_SLOTS],
+    ) -> Responder<'a, S> {
+        Responder {
+            slots,
+            transcript: Transcript::new(),
+            state: Some(version::State {}.into()),
+        }
+    }
+
+    // Return the serialized output message, including the serialized error
+    // response, and an error if the responder should be shutdown.
+    pub fn handle_msg<'b>(
+        &mut self,
+        req: &[u8],
+        rsp: &'b mut [u8],
+    ) -> (&'b [u8], Result<(), ResponderError>) {
+        let state = self.state.take().unwrap();
+        let (out, next_state, result) =
+            state.handle(req, rsp, &mut self.transcript, &self.slots);
+        self.state = Some(next_state);
+        (out, result)
+    }
+
+    // Return the current state of the responder
+    //
+    // It's safe to unwrap here, as the invariant of a Responder is that the
+    // `state` Option is only `None` during a `recv` call.
+    pub fn state(&self) -> &AllStates {
+        self.state.as_ref().unwrap()
+    }
+
+    pub fn transcript(&self) -> &Transcript {
+        &self.transcript
+    }
+
+    pub fn slots(&self) -> &[Option<FilledSlot<'a, S>>; config::NUM_SLOTS] {
+        &self.slots
+    }
 }
 
 /// Go back to the Version state and process a GetVersion message.
@@ -42,10 +239,10 @@ macro_rules! reset_on_get_version {
         match GetVersion::parse_header($req) {
             Ok(true) => {
                 // Go back to the beginning!
-                let (data, cap_state) =
+                let (size, cap_state) =
                     version::State {}.handle_msg($req, $rsp, $transcript)?;
 
-                return Ok((data, Transition::Capabilities(cap_state)));
+                return Ok((size, cap_state));
             }
             Err(e) => return Err(e.into()),
             _ => (),


### PR DESCRIPTION
Prior to this commit, all the internal states of the Responder were exposed to
the user, in a typestate style API. While safe, this is a bit unwieldy and
requires every user to duplicate the flow of the state machine. This commit
simplifies the user API dramatically such that users now only have to make a
single API call, `Responder::handle_msg`, when a message is received over the
transport.

In order to make this code compile, and avoid borrow check issues, the internal
states once again return the amount of data written rather than a slice of the
output buffer. However, a slice is still presented in the user API, maintaining
the ergonomics of prior versions.

Since we now have an `AllStates` wrapper, the individual `Transition` enums for
each state also are gone, reducing the amount of state specific code necessary.

This change also provides conversion between the `ResponderError` and the spdm
Error message in `msgs::Error`. If an error is returned, the spdm error message
is written to the output buffer similar to any successful response.