### PR TITLE
Improve ergonomics of the Requester

### DIFF
--- a/src/msgs/algorithms.rs
+++ b/src/msgs/algorithms.rs
@@ -6,6 +6,7 @@ use super::encoding::{ReadError, ReadErrorKind, Reader, WriteError, Writer};
 use super::Msg;
 
 use bitflags::bitflags;
+use core::str::FromStr;
 
 bitflags! {
    /// The base asymetric signing algorithm defined in the SPDM spec
@@ -39,6 +40,30 @@ impl BaseAsymAlgo {
     }
 }
 
+impl FromStr for BaseAsymAlgo {
+    type Err = ReadError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let algo = match s {
+            "RSASSA_2048" => BaseAsymAlgo::RSASSA_2048,
+            "RSAPSS_2048" => BaseAsymAlgo::RSAPSS_2048,
+            "RSASSA_3072" => BaseAsymAlgo::RSASSA_3072,
+            "RSAPSS_3072" => BaseAsymAlgo::RSAPSS_3072,
+            "ECDSA_ECC_NIST_P256" => BaseAsymAlgo::ECDSA_ECC_NIST_P256,
+            "RSASSA_4096" => BaseAsymAlgo::RSASSA_4096,
+            "RSAPSS_4096" => BaseAsymAlgo::RSAPSS_4096,
+            "ECDSA_ECC_NIST_P384" => BaseAsymAlgo::ECDSA_ECC_NIST_P384,
+            "ECDSA_ECC_NIST_P521" => BaseAsymAlgo::ECDSA_ECC_NIST_P521,
+            _ => {
+                return Err(ReadError::new(
+                    "BaseAsymAlgo",
+                    ReadErrorKind::UnexpectedValue,
+                ))
+            }
+        };
+        Ok(algo)
+    }
+}
+
 bitflags! {
     /// The base hash algorithm defined in the SPDM spec.
     #[derive(Default)]
@@ -62,6 +87,27 @@ impl BaseHashAlgo {
             H::SHA_512 | H::SHA3_512 => 64,
             _ => unreachable!(),
         }
+    }
+}
+
+impl FromStr for BaseHashAlgo {
+    type Err = ReadError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let algo = match s {
+            "SHA_256" => BaseHashAlgo::SHA_256,
+            "SHA_384" => BaseHashAlgo::SHA_384,
+            "SHA_512" => BaseHashAlgo::SHA_512,
+            "SHA3_256" => BaseHashAlgo::SHA3_256,
+            "SHA3_384" => BaseHashAlgo::SHA3_384,
+            "SHA3_512" => BaseHashAlgo::SHA3_512,
+            _ => {
+                return Err(ReadError::new(
+                    "BaseHashAlgo",
+                    ReadErrorKind::UnexpectedValue,
+                ))
+            }
+        };
+        Ok(algo)
     }
 }
 

--- a/src/requester.rs
+++ b/src/requester.rs
@@ -21,12 +21,13 @@ pub mod version;
 mod error;
 
 use crate::msgs::Msg;
+use crate::Transcript;
 pub use error::RequesterError;
 
-/// Enter the first state of the Requester state machine, the `Version` state.
-pub fn start() -> version::State {
-    version::State {}
-}
+use crate::config;
+use crate::crypto::{FilledSlot, Signer};
+
+use core::convert::From;
 
 /// We expect a messsage of the given type.
 ///
@@ -42,5 +43,255 @@ pub fn expect<T: Msg>(buf: &[u8]) -> Result<(), RequesterError> {
             got: buf[0],
         }),
         Err(e) => Err(e.into()),
+    }
+}
+
+// Internal data shared between `RequesterInit` and `RequesterSession` states.
+struct RequesterData<'a, S: Signer> {
+    // Do we need more than one of these? Do we expect that different slots for
+    // a responder will have different root certs?
+    root_cert: &'a [u8],
+
+    // Will eventually be used for mutual auth
+    slots: [Option<FilledSlot<'a, S>>; config::NUM_SLOTS],
+
+    transcript: Transcript,
+    // This Option allows us to move between AllStates variants at runtime, without having
+    // to take self by value.
+    state: Option<AllStates>,
+}
+
+/// The `RequesterInit` state handles the "autonomous" part of the
+/// protocol, as dictated by negotiated capabilities, until a secure session is
+/// established. Once a secure session is established, users can send and
+/// receive application specific messages from the `RequesterSession` state.
+pub struct RequesterInit<'a, S: Signer> {
+    data: RequesterData<'a, S>,
+}
+
+/// In the `RequesterSession` state, the a secure session has been
+/// established and the user can send encrypted messages and request
+/// measurements at will.
+pub struct RequesterSession<'a, S: Signer> {
+    _data: RequesterData<'a, S>,
+}
+
+impl<'a, S: Signer> From<RequesterInit<'a, S>> for RequesterSession<'a, S> {
+    fn from(state: RequesterInit<'a, S>) -> Self {
+        RequesterSession { _data: state.data }
+    }
+}
+
+impl<'a, S: Signer> RequesterInit<'a, S> {
+    pub fn new(
+        root_cert: &'a [u8],
+        slots: [Option<FilledSlot<'a, S>>; config::NUM_SLOTS],
+    ) -> RequesterInit<'a, S> {
+        RequesterInit {
+            data: RequesterData {
+                root_cert,
+                slots,
+                transcript: Transcript::new(),
+                state: Some(version::State {}.into()),
+            },
+        }
+    }
+
+    /// The user calls `next_request` to write the next SPDM request into the
+    /// provided buffer. The user can then send that request over the transport.
+    ///
+    /// A `RequesterError::InitializationComplete` error  will be returned if
+    /// this method is called when initialization is complete. In this case,
+    /// the user should call the `begin_session` method.
+    pub fn next_request<'b>(
+        &mut self,
+        buf: &'b mut [u8],
+    ) -> Result<&'b [u8], RequesterError> {
+        let state = self.data.state.as_mut().unwrap();
+        if let AllStates::NewSession = state {
+            return Err(RequesterError::InitializationComplete);
+        }
+        state.write_req(buf, &mut self.data.transcript)
+    }
+
+    /// The user calls `handle_msg` when a response is received over the
+    /// transport.
+    ///
+    /// `Ok(true)` will be returned when initialization is complete. At this
+    /// point the user should call the `begin_session` method.
+    pub fn handle_msg<'b>(
+        &mut self,
+        rsp: &[u8],
+    ) -> Result<bool, RequesterError> {
+        let state = self.data.state.take().unwrap();
+        let (next_state, result) = state.handle_msg(
+            rsp,
+            &mut self.data.transcript,
+            &self.data.root_cert,
+        );
+        self.data.state = Some(next_state);
+
+        match result {
+            Ok(()) => {
+                if let Some(AllStates::NewSession) = self.data.state {
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Transition to the RequesterSession state
+    pub fn begin_session(self) -> RequesterSession<'a, S> {
+        self.into()
+    }
+
+    // Return the current state of the requester
+    pub fn state(&self) -> &AllStates {
+        self.data.state.as_ref().unwrap()
+    }
+
+    pub fn transcript(&self) -> &Transcript {
+        &self.data.transcript
+    }
+
+    pub fn slots(&self) -> &[Option<FilledSlot<'a, S>>; config::NUM_SLOTS] {
+        &self.data.slots
+    }
+}
+
+/// `AllStates` is a container for all the states in a Requester.
+///
+/// It serves to make the internal typestate pattern more egronomic for users,
+/// and hide the details of the SPDM protocol. The protocol states are moved
+/// between based on the capability negotiation of the requester and responder.
+pub enum AllStates {
+    // A special state that indicates the responder has terminated and the
+    // transport should close its "connection".
+    Error,
+    Version(version::State),
+    Capabilities(capabilities::State),
+    Algorithms(algorithms::State),
+    IdAuth(id_auth::State),
+    Challenge(challenge::State),
+
+    // TODO: Fill this in with an actual state once sessions are implemented.
+    NewSession,
+}
+impl From<version::State> for AllStates {
+    fn from(state: version::State) -> AllStates {
+        AllStates::Version(state)
+    }
+}
+
+impl From<capabilities::State> for AllStates {
+    fn from(state: capabilities::State) -> AllStates {
+        AllStates::Capabilities(state)
+    }
+}
+
+impl From<algorithms::State> for AllStates {
+    fn from(state: algorithms::State) -> AllStates {
+        AllStates::Algorithms(state)
+    }
+}
+
+impl From<id_auth::State> for AllStates {
+    fn from(state: id_auth::State) -> AllStates {
+        AllStates::IdAuth(state)
+    }
+}
+
+impl From<challenge::State> for AllStates {
+    fn from(state: challenge::State) -> AllStates {
+        AllStates::Challenge(state)
+    }
+}
+
+impl AllStates {
+    fn write_req<'a>(
+        &mut self,
+        buf: &'a mut [u8],
+        transcript: &mut Transcript,
+    ) -> Result<&'a [u8], RequesterError> {
+        match self {
+            AllStates::Version(state) => {
+                state.write_get_version(buf, transcript)
+            }
+            AllStates::Capabilities(state) => state.write_msg(buf, transcript),
+            AllStates::Algorithms(state) => state.write_msg(buf, transcript),
+            AllStates::IdAuth(state) => {
+                if state.digests.is_none() {
+                    // We need to send the GET_DIGESTS request
+                    state.write_get_digests_msg(buf, transcript)
+                } else {
+                    // TODO: Retrieve certs for all slots that have digests.
+                    // See SPDM 1.2 sec 10.4.1: Connection Behavior after VCA
+                    //
+                    // This requires changes to the id_auth state to not
+                    // automatically transition after retrieving one cert.
+                    //
+                    // Tracked in https://github.com/oxidecomputer/spdm/issues/29
+                    let slot = 0;
+                    state.write_get_certificate_msg(slot, buf, transcript)
+                }
+            }
+            AllStates::Challenge(state) => state.write_msg(buf, transcript),
+            _ => unimplemented!(),
+        }
+    }
+
+    fn handle_msg<'a>(
+        self,
+        rsp: &[u8],
+        transcript: &mut Transcript,
+        root_cert: &'a [u8],
+    ) -> (AllStates, Result<(), RequesterError>) {
+        let result = match self {
+            AllStates::Version(state) => {
+                state.handle_msg(rsp, transcript).map(|s| s.into())
+            }
+            AllStates::Capabilities(state) => {
+                state.handle_msg(rsp, transcript).map(|s| s.into())
+            }
+            AllStates::Algorithms(state) => {
+                state.handle_msg(rsp, transcript).map(|s| s.into())
+            }
+            AllStates::IdAuth(mut state) => {
+                if state.digests.is_none() {
+                    // Self is taken by ref here so we return immediately.
+                    let result = state.handle_digests(rsp, transcript);
+                    return (state.into(), result);
+                } else {
+                    state.handle_certificate(rsp, transcript).map(|s| s.into())
+                }
+            }
+            AllStates::Challenge(state) => {
+                // We haven't implemented any other states, so just go to
+                // `NewSession`.
+                let result = state.handle_msg(rsp, transcript, root_cert);
+                return (AllStates::NewSession, result.map(|_| ()));
+            }
+            _ => unimplemented!(),
+        };
+        match result {
+            Ok(next_state) => (next_state, Ok(())),
+            Err(e) => (AllStates::Error, Err(e)),
+        }
+    }
+
+    // Return the name of the current state
+    pub fn name(&self) -> &'static str {
+        match self {
+            AllStates::Error => "Error",
+            AllStates::Version(_) => "Version",
+            AllStates::Capabilities(_) => "Capabilities",
+            AllStates::Algorithms(_) => "Algorithms",
+            AllStates::IdAuth(_) => "IdAuth",
+            AllStates::Challenge(_) => "Challenge",
+            AllStates::NewSession => "NewSession",
+        }
     }
 }

--- a/src/requester/error.rs
+++ b/src/requester/error.rs
@@ -29,6 +29,10 @@ pub enum RequesterError {
 
     // A certificate could not be parsed properly
     InvalidCert,
+
+    // Protocol initialization is complete and a secure session now exists.
+    // The user must transition to the `RequesterSession` state.
+    InitializationComplete,
 }
 
 impl From<WriteError> for RequesterError {
@@ -77,6 +81,9 @@ requester does not support"
             }
             RequesterError::InvalidCert => {
                 write!(f, "invalid certificate")
+            }
+            RequesterError::InitializationComplete => {
+                write!(f, "initialization complete")
             }
         }
     }


### PR DESCRIPTION
All internal, capability driven request response messages of the SPDM protocol
have a unique `State` as part of a typestate pattern. The prior version of this
code required the user to manage the transition between all of these requester
states manually. Furthermore, each state could require different arguments
specific to the message sequence being exchanged. This required the user of this
library to have internal knowledge of the SPDM protocol, and also resulted in
much duplication of code by different users. The upshot of this strategy is that
the Rust type system made it impossible to send an invalid request at a given
state of the protocol, and the handling code automatically checks that the
expected response is received. The goal of this change then is to maintain this
safety while reducing unnecessary user code duplication and complexity.

The key insight behind this change is to realize there are 2 distinct phases to
the SPDM protocol:
 * Secure session initialization
 * Application level messages inside a secure session

Secure session initialization can have its state transitions automated using
user configuration detailing capabilities and algorithms. Application level
messaging, including on demand measurement requests, must be driven by the user.

We bundle the initialization into the `RequesterInit` state. Users interact by
repeatedly calling `next_request` to serialize a request to send, and then
handling the response in the `handle_msg` method. Note that we still do not rely
on any given transport implementation or even trait here, and thus maintain the
ability to use SPDM in both no_std and async contexts.

Once session initialization is complete, `handle_msg` returns `Ok(true)`
instructing the user to transition to the `RequesterSession` state. Note that
this state is not fully implemented, and neither is the actual ability to setup
a secure session. This code just lays out the patterns needed and transitions
the existing code base.  One could ask: "Why not transition directly to the
RequesterSession state automatically, following a more typical typestate
pattern?". The answer is mainly ergonomics again. There are many initialization
messages, and it's somewhat easier to check a bool than issue a match after each
`handle_msg` call.This is easy to change later, if we decide this isn't the
right decision though.