### PR TITLE
build: Disable deafult features on rand dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,13 @@ license = "MPL 2.0"
 
 [dependencies]
 bitflags = "1.3"
-rand = {version = "0.8", features = ["getrandom"]}
 ring = "0.16.20"
 webpki = "0.22.0"
+
+[dependencies.rand]
+version = "0.8"
+default-features = false
+features = [ "getrandom" ]
 
 [dev-dependencies]
 test-utils = { path = "test-utils" }


### PR DESCRIPTION
The rand crate follows the convention of having an 'std' feature that
enables stuff that depends on 'std'. This feature is enabled by default.
Disabling the default features for this crate allows us to build for
targets that aren't supported by the std lib (thumbv8m.main-none-eabihf
in my case).