### PR TITLE
Start decoupling, simplifying, and making errors more specific

### DIFF
--- a/src/crypto/pki.rs
+++ b/src/crypto/pki.rs
@@ -9,7 +9,7 @@ use core::convert::TryFrom;
 
 use crate::msgs::algorithms::BaseAsymAlgo;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Error {
     InvalidCert,
     ValidationFailed,

--- a/src/msgs/algorithms.rs
+++ b/src/msgs/algorithms.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use super::common::{DigestSize, SignatureSize};
-use super::encoding::{ReadError, ReadErrorKind, Reader, WriteError, Writer};
+use super::encoding::{BufferFullError, ReadError, Reader, Writer};
 use super::Msg;
 
 use bitflags::bitflags;
@@ -43,8 +43,11 @@ impl BaseAsymAlgo {
     }
 }
 
+#[derive(Debug, PartialEq)]
+pub struct ParseBaseAsymAlgoError;
+
 impl FromStr for BaseAsymAlgo {
-    type Err = ReadError;
+    type Err = ParseBaseAsymAlgoError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let algo = match s {
             "RSASSA_2048" => BaseAsymAlgo::RSASSA_2048,
@@ -57,10 +60,7 @@ impl FromStr for BaseAsymAlgo {
             "ECDSA_ECC_NIST_P384" => BaseAsymAlgo::ECDSA_ECC_NIST_P384,
             "ECDSA_ECC_NIST_P521" => BaseAsymAlgo::ECDSA_ECC_NIST_P521,
             _ => {
-                return Err(ReadError::new(
-                    "BaseAsymAlgo",
-                    ReadErrorKind::UnexpectedValue,
-                ))
+                return Err(ParseBaseAsymAlgoError);
             }
         };
         Ok(algo)
@@ -94,8 +94,11 @@ impl BaseHashAlgo {
     }
 }
 
+#[derive(Debug, PartialEq)]
+pub struct ParseBaseHashAlgoError;
+
 impl FromStr for BaseHashAlgo {
-    type Err = ReadError;
+    type Err = ParseBaseHashAlgoError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let algo = match s {
             "SHA_256" => BaseHashAlgo::SHA_256,
@@ -105,10 +108,7 @@ impl FromStr for BaseHashAlgo {
             "SHA3_384" => BaseHashAlgo::SHA3_384,
             "SHA3_512" => BaseHashAlgo::SHA3_512,
             _ => {
-                return Err(ReadError::new(
-                    "BaseHashAlgo",
-                    ReadErrorKind::UnexpectedValue,
-                ))
+                return Err(ParseBaseHashAlgoError);
             }
         };
         Ok(algo)
@@ -243,6 +243,20 @@ impl Default for AlgorithmRequest {
     }
 }
 
+#[derive(Debug, PartialEq)]
+pub enum ParseAlgorithmRequestError {
+    IncorrectFixedAlgCount,
+    InvalidFixedAlgorithm,
+    InvalidAlgorithmType,
+    Read(ReadError),
+}
+
+impl From<ReadError> for ParseAlgorithmRequestError {
+    fn from(e: ReadError) -> Self {
+        ParseAlgorithmRequestError::Read(e)
+    }
+}
+
 impl AlgorithmRequest {
     /// Return the number of bytes required to fit fixed spdm algorithm options
     /// for the given algorithm type.
@@ -260,7 +274,7 @@ impl AlgorithmRequest {
     }
 
     /// Serialize an AlgorithmRequest structure
-    pub fn write(&self, w: &mut Writer) -> Result<usize, WriteError> {
+    pub fn write(&self, w: &mut Writer) -> Result<usize, BufferFullError> {
         match &self {
             AlgorithmRequest::Dhe(algo) => {
                 w.put(DheAlgorithm::TYPE)?;
@@ -288,23 +302,21 @@ impl AlgorithmRequest {
 
     // Deserialize an AlgorithmRequest structure
     pub fn read(
-        msg_name: &'static str,
         r: &mut Reader,
-    ) -> Result<AlgorithmRequest, ReadError> {
+    ) -> Result<AlgorithmRequest, ParseAlgorithmRequestError> {
         match r.get_byte()? {
             DheAlgorithm::TYPE => {
                 let ext_count = r.get_bits(4)? as usize;
                 let fixed_count = r.get_bits(4)?;
                 if fixed_count != DheAlgorithm::FIXED_ALG_COUNT {
-                    return Err(ReadError::new(
-                        msg_name,
-                        ReadErrorKind::UnexpectedValue,
-                    ));
+                    return Err(
+                        ParseAlgorithmRequestError::IncorrectFixedAlgCount,
+                    );
                 }
                 let supported = r.get_u16()?;
                 let supported = DheFixedAlgorithms::from_bits(supported)
                     .ok_or_else(|| {
-                        ReadError::new(msg_name, ReadErrorKind::InvalidBitsSet)
+                        ParseAlgorithmRequestError::InvalidFixedAlgorithm
                     })?;
                 r.skip_ignored(4 * ext_count)?;
                 Ok(AlgorithmRequest::Dhe(DheAlgorithm { supported }))
@@ -314,15 +326,14 @@ impl AlgorithmRequest {
                 let ext_count = r.get_bits(4)? as usize;
                 let fixed_count = r.get_bits(4)?;
                 if fixed_count != AeadAlgorithm::FIXED_ALG_COUNT {
-                    return Err(ReadError::new(
-                        msg_name,
-                        ReadErrorKind::UnexpectedValue,
-                    ));
+                    return Err(
+                        ParseAlgorithmRequestError::IncorrectFixedAlgCount,
+                    );
                 }
                 let supported = r.get_u16()?;
                 let supported = AeadFixedAlgorithms::from_bits(supported)
                     .ok_or_else(|| {
-                        ReadError::new(msg_name, ReadErrorKind::InvalidBitsSet)
+                        ParseAlgorithmRequestError::InvalidFixedAlgorithm
                     })?;
                 r.skip_ignored(4 * ext_count)?;
                 Ok(AlgorithmRequest::Aead(AeadAlgorithm { supported }))
@@ -332,19 +343,15 @@ impl AlgorithmRequest {
                 let ext_count = r.get_bits(4)? as usize;
                 let fixed_count = r.get_bits(4)?;
                 if fixed_count != ReqBaseAsymAlgorithm::FIXED_ALG_COUNT {
-                    return Err(ReadError::new(
-                        msg_name,
-                        ReadErrorKind::UnexpectedValue,
-                    ));
+                    return Err(
+                        ParseAlgorithmRequestError::IncorrectFixedAlgCount,
+                    );
                 }
                 let supported = r.get_u16()?;
                 let supported =
                     ReqBaseAsymFixedAlgorithms::from_bits(supported)
                         .ok_or_else(|| {
-                            ReadError::new(
-                                msg_name,
-                                ReadErrorKind::InvalidBitsSet,
-                            )
+                            ParseAlgorithmRequestError::InvalidFixedAlgorithm
                         })?;
                 r.skip_ignored(4 * ext_count)?;
                 Ok(AlgorithmRequest::ReqBaseAsym(ReqBaseAsymAlgorithm {
@@ -356,19 +363,15 @@ impl AlgorithmRequest {
                 let ext_count = r.get_bits(4)? as usize;
                 let fixed_count = r.get_bits(4)?;
                 if fixed_count != KeyScheduleAlgorithm::FIXED_ALG_COUNT {
-                    return Err(ReadError::new(
-                        msg_name,
-                        ReadErrorKind::UnexpectedValue,
-                    ));
+                    return Err(
+                        ParseAlgorithmRequestError::IncorrectFixedAlgCount,
+                    );
                 }
                 let supported = r.get_u16()?;
                 let supported =
                     KeyScheduleFixedAlgorithms::from_bits(supported)
                         .ok_or_else(|| {
-                            ReadError::new(
-                                msg_name,
-                                ReadErrorKind::InvalidBitsSet,
-                            )
+                            ParseAlgorithmRequestError::InvalidFixedAlgorithm
                         })?;
                 r.skip_ignored(4 * ext_count)?;
                 Ok(AlgorithmRequest::KeySchedule(KeyScheduleAlgorithm {
@@ -376,8 +379,31 @@ impl AlgorithmRequest {
                 }))
             }
 
-            _ => Err(ReadError::new(msg_name, ReadErrorKind::UnexpectedValue)),
+            _ => Err(ParseAlgorithmRequestError::InvalidAlgorithmType),
         }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum ParseNegotiateAlgorithmsError {
+    TooLarge,
+    MaxAlgorithmRequestsExceeded,
+    InvalidMeasurementSpec,
+    InvalidBaseAsymAlgo,
+    InvalidBaseHashAlgo,
+    Read(ReadError),
+    AlgorithmRequest(ParseAlgorithmRequestError),
+}
+
+impl From<ReadError> for ParseNegotiateAlgorithmsError {
+    fn from(e: ReadError) -> Self {
+        ParseNegotiateAlgorithmsError::Read(e)
+    }
+}
+
+impl From<ParseAlgorithmRequestError> for ParseNegotiateAlgorithmsError {
+    fn from(e: ParseAlgorithmRequestError) -> Self {
+        ParseNegotiateAlgorithmsError::AlgorithmRequest(e)
     }
 }
 
@@ -405,7 +431,9 @@ impl Msg for NegotiateAlgorithms {
 
     const SPDM_CODE: u8 = 0xE3;
 
-    fn write_body(&self, w: &mut Writer) -> Result<usize, WriteError> {
+    type WriteError = BufferFullError;
+
+    fn write_body(&self, w: &mut Writer) -> Result<usize, BufferFullError> {
         w.put(self.num_algorithm_requests)?;
         w.put_reserved(1)?;
         w.put_u16(self.msg_length())?;
@@ -422,14 +450,15 @@ impl Msg for NegotiateAlgorithms {
 }
 
 impl NegotiateAlgorithms {
-    pub fn parse_body(buf: &[u8]) -> Result<NegotiateAlgorithms, ReadError> {
-        let mut r = Reader::new(Self::NAME, buf);
+    pub fn parse_body(
+        buf: &[u8],
+    ) -> Result<NegotiateAlgorithms, ParseNegotiateAlgorithmsError> {
+        let mut r = Reader::new(buf);
         let num_requests = r.get_byte()?;
         if num_requests as usize > MAX_ALGORITHM_REQUESTS {
-            return Err(ReadError::new(
-                Self::NAME,
-                ReadErrorKind::ImplementationLimitReached,
-            ));
+            return Err(
+                ParseNegotiateAlgorithmsError::MaxAlgorithmRequestsExceeded,
+            );
         }
 
         r.skip_reserved(1)?;
@@ -437,15 +466,12 @@ impl NegotiateAlgorithms {
         // TODO: Use this for validation?
         let length = r.get_u16()?;
         if length > 128 {
-            return Err(ReadError::new(
-                Self::NAME,
-                ReadErrorKind::SpdmLimitReached,
-            ));
+            return Err(ParseNegotiateAlgorithmsError::TooLarge);
         }
         let spec = r.get_byte()?;
         let measurement_spec =
             MeasurementSpec::from_bits(spec).ok_or_else(|| {
-                ReadError::new(Self::NAME, ReadErrorKind::InvalidBitsSet)
+                ParseNegotiateAlgorithmsError::InvalidMeasurementSpec
             })?;
 
         r.skip_reserved(1)?;
@@ -453,13 +479,13 @@ impl NegotiateAlgorithms {
         let algo = r.get_u32()?;
         let base_asym_algo =
             BaseAsymAlgo::from_bits(algo).ok_or_else(|| {
-                ReadError::new(Self::NAME, ReadErrorKind::InvalidBitsSet)
+                ParseNegotiateAlgorithmsError::InvalidBaseAsymAlgo
             })?;
 
         let algo = r.get_u32()?;
         let base_hash_algo =
             BaseHashAlgo::from_bits(algo).ok_or_else(|| {
-                ReadError::new(Self::NAME, ReadErrorKind::InvalidBitsSet)
+                ParseNegotiateAlgorithmsError::InvalidBaseHashAlgo
             })?;
 
         r.skip_reserved(12)?;
@@ -493,9 +519,9 @@ impl NegotiateAlgorithms {
         r: &mut Reader,
         num_requests: u8,
         requests: &mut [AlgorithmRequest; MAX_ALGORITHM_REQUESTS],
-    ) -> Result<(), ReadError> {
+    ) -> Result<(), ParseNegotiateAlgorithmsError> {
         for i in 0..num_requests as usize {
-            requests[i] = AlgorithmRequest::read(Self::NAME, r)?;
+            requests[i] = AlgorithmRequest::read(r)?;
         }
         Ok(())
     }
@@ -511,7 +537,7 @@ impl NegotiateAlgorithms {
     fn write_algorithm_requests(
         &self,
         w: &mut Writer,
-    ) -> Result<usize, WriteError> {
+    ) -> Result<usize, BufferFullError> {
         for i in 0..self.num_algorithm_requests as usize {
             self.algorithm_requests[i].write(w)?;
         }
@@ -519,8 +545,50 @@ impl NegotiateAlgorithms {
     }
 }
 
+#[derive(Debug, PartialEq)]
+pub enum ParseAlgorithmsError {
+    MaxAlgorithmResponsesExceeded,
+    InvalidMeasurementSpecSelected,
+    MoreThanOneMeasurementSpecSelected,
+    InvalidMeasurementHashAlgoSelected,
+    MoreThanOneMeasurementHashAlgoSelected,
+    InvalidBaseAsymAlgoSelected,
+    MoreThanOneBaseAsymAlgoSelected,
+    InvalidBaseHashAlgoSelected,
+    MoreThanOneBaseHashAlgoSelected,
+    AlgorithmsResponse(ParseAlgorithmResponseError),
+    AlgorithmsRequest(ParseAlgorithmRequestError),
+    Read(ReadError),
+}
+
+impl From<ReadError> for ParseAlgorithmsError {
+    fn from(e: ReadError) -> Self {
+        ParseAlgorithmsError::Read(e)
+    }
+}
+
+impl From<ParseAlgorithmResponseError> for ParseAlgorithmsError {
+    fn from(e: ParseAlgorithmResponseError) -> Self {
+        ParseAlgorithmsError::AlgorithmsResponse(e)
+    }
+}
+
+impl From<ParseAlgorithmRequestError> for ParseAlgorithmsError {
+    fn from(e: ParseAlgorithmRequestError) -> Self {
+        ParseAlgorithmsError::AlgorithmsRequest(e)
+    }
+}
+
 // The format is the same for both messages
 pub type AlgorithmResponse = AlgorithmRequest;
+
+#[derive(Debug, PartialEq)]
+pub enum ParseAlgorithmResponseError {
+    MoreThanOneDheAlgoSelected,
+    MoreThanOneAeadAlgoSelected,
+    MoreThanOneBaseAsymAlgoSelected,
+    MoreThanOneKeySchedule,
+}
 
 /// The algorithms selected by the responder as part of negotiation
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
@@ -540,7 +608,9 @@ impl Msg for Algorithms {
 
     const SPDM_CODE: u8 = 0x63;
 
-    fn write_body(&self, w: &mut Writer) -> Result<usize, WriteError> {
+    type WriteError = BufferFullError;
+
+    fn write_body(&self, w: &mut Writer) -> Result<usize, BufferFullError> {
         w.put(self.num_algorithm_responses)?;
         w.put_reserved(1)?;
         w.put_u16(self.msg_length())?;
@@ -562,14 +632,11 @@ impl Msg for Algorithms {
 }
 
 impl Algorithms {
-    pub fn parse_body(buf: &[u8]) -> Result<Algorithms, ReadError> {
-        let mut r = Reader::new(Self::NAME, buf);
+    pub fn parse_body(buf: &[u8]) -> Result<Algorithms, ParseAlgorithmsError> {
+        let mut r = Reader::new(buf);
         let num_responses = r.get_byte()?;
         if num_responses as usize > MAX_ALGORITHM_REQUESTS {
-            return Err(ReadError::new(
-                Self::NAME,
-                ReadErrorKind::ImplementationLimitReached,
-            ));
+            return Err(ParseAlgorithmsError::MaxAlgorithmResponsesExceeded);
         }
 
         r.skip_reserved(1)?;
@@ -580,10 +647,12 @@ impl Algorithms {
         let selection = r.get_byte()?;
         let measurement_spec_selected = MeasurementSpec::from_bits(selection)
             .ok_or_else(|| {
-            ReadError::new(Self::NAME, ReadErrorKind::InvalidBitsSet)
+            ParseAlgorithmsError::InvalidMeasurementSpecSelected
         })?;
         if measurement_spec_selected.bits().count_ones() != 1 {
-            return Self::too_many_bits();
+            return Err(
+                ParseAlgorithmsError::MoreThanOneMeasurementSpecSelected,
+            );
         }
 
         r.skip_reserved(1)?;
@@ -591,28 +660,26 @@ impl Algorithms {
         let selection = r.get_u32()?;
         let measurement_hash_algo_selected = BaseHashAlgo::from_bits(selection)
             .ok_or_else(|| {
-                ReadError::new(Self::NAME, ReadErrorKind::InvalidBitsSet)
+                ParseAlgorithmsError::InvalidMeasurementHashAlgoSelected
             })?;
         if measurement_hash_algo_selected.bits().count_ones() != 1 {
-            return Self::too_many_bits();
+            return Err(
+                ParseAlgorithmsError::MoreThanOneMeasurementHashAlgoSelected,
+            );
         }
 
         let selection = r.get_u32()?;
         let base_asym_algo_selected = BaseAsymAlgo::from_bits(selection)
-            .ok_or_else(|| {
-                ReadError::new(Self::NAME, ReadErrorKind::InvalidBitsSet)
-            })?;
+            .ok_or_else(|| ParseAlgorithmsError::InvalidBaseAsymAlgoSelected)?;
         if base_asym_algo_selected.bits().count_ones() != 1 {
-            return Self::too_many_bits();
+            return Err(ParseAlgorithmsError::MoreThanOneBaseAsymAlgoSelected);
         }
 
         let selection = r.get_u32()?;
         let base_hash_algo_selected = BaseHashAlgo::from_bits(selection)
-            .ok_or_else(|| {
-                ReadError::new(Self::NAME, ReadErrorKind::InvalidBitsSet)
-            })?;
+            .ok_or_else(|| ParseAlgorithmsError::InvalidBaseHashAlgoSelected)?;
         if base_hash_algo_selected.bits().count_ones() != 1 {
-            return Self::too_many_bits();
+            return Err(ParseAlgorithmsError::MoreThanOneBaseHashAlgoSelected);
         }
 
         r.skip_reserved(12)?;
@@ -648,7 +715,7 @@ impl Algorithms {
     fn write_algorithm_responses(
         &self,
         w: &mut Writer,
-    ) -> Result<usize, WriteError> {
+    ) -> Result<usize, BufferFullError> {
         for i in 0..self.num_algorithm_responses as usize {
             self.algorithm_responses[i].write(w)?;
         }
@@ -659,9 +726,9 @@ impl Algorithms {
         r: &mut Reader,
         num_responses: u8,
         responses: &mut [AlgorithmResponse; MAX_ALGORITHM_REQUESTS],
-    ) -> Result<(), ReadError> {
+    ) -> Result<(), ParseAlgorithmsError> {
         for i in 0..num_responses as usize {
-            responses[i] = AlgorithmResponse::read(Self::NAME, r)?;
+            responses[i] = AlgorithmResponse::read(r)?;
             Self::ensure_only_one_bit_set(&responses[i])?;
         }
         Ok(())
@@ -669,34 +736,36 @@ impl Algorithms {
 
     fn ensure_only_one_bit_set(
         response: &AlgorithmResponse,
-    ) -> Result<(), ReadError> {
+    ) -> Result<(), ParseAlgorithmsError> {
         match response {
             AlgorithmResponse::Dhe(algo) => {
                 if algo.supported.bits().count_ones() != 1 {
-                    Self::too_many_bits()?;
+                    return Err(
+                        ParseAlgorithmResponseError::MoreThanOneDheAlgoSelected
+                            .into(),
+                    );
                 }
             }
             AlgorithmResponse::Aead(algo) => {
                 if algo.supported.bits().count_ones() != 1 {
-                    Self::too_many_bits()?;
+                    return Err(ParseAlgorithmResponseError::MoreThanOneAeadAlgoSelected.into());
                 }
             }
             AlgorithmResponse::ReqBaseAsym(algo) => {
                 if algo.supported.bits().count_ones() != 1 {
-                    Self::too_many_bits()?;
+                    return Err(ParseAlgorithmResponseError::MoreThanOneBaseAsymAlgoSelected.into());
                 }
             }
             AlgorithmResponse::KeySchedule(algo) => {
                 if algo.supported.bits().count_ones() != 1 {
-                    Self::too_many_bits()?;
+                    return Err(
+                        ParseAlgorithmResponseError::MoreThanOneKeySchedule
+                            .into(),
+                    );
                 }
             }
         }
         Ok(())
-    }
-
-    fn too_many_bits() -> Result<Algorithms, ReadError> {
-        Err(ReadError::new(Self::NAME, ReadErrorKind::TooManyBitsSet))
     }
 }
 

--- a/src/msgs/capabilities.rs
+++ b/src/msgs/capabilities.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use super::encoding::{ReadError, ReadErrorKind, Reader, WriteError, Writer};
+use super::encoding::{BufferFullError, ReadError, Reader, Writer};
 use super::Msg;
 
 use bitflags::bitflags;
@@ -28,10 +28,14 @@ bitflags! {
     }
 }
 
+/// The capability failed to parse
+#[derive(Debug, PartialEq)]
+pub struct ParseReqCapabilityError;
+
 // We only allow strings for fields we want the user to configure, excluding
 // things like `PSK_CAP_MASK`.
 impl FromStr for ReqFlags {
-    type Err = ReadError;
+    type Err = ParseReqCapabilityError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let flag = match s {
             "CERT_CAP" => ReqFlags::CERT_CAP,
@@ -49,13 +53,22 @@ impl FromStr for ReqFlags {
             }
             "PUB_KEY_ID_CAP" => ReqFlags::PUB_KEY_ID_CAP,
             _ => {
-                return Err(ReadError::new(
-                    "CAPABILITIES",
-                    ReadErrorKind::UnexpectedValue,
-                ))
+                return Err(ParseReqCapabilityError);
             }
         };
         Ok(flag)
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum ParseGetCapabilitiesError {
+    InvalidBitsSet,
+    Read(ReadError),
+}
+
+impl From<ReadError> for ParseGetCapabilitiesError {
+    fn from(e: ReadError) -> Self {
+        ParseGetCapabilitiesError::Read(e)
     }
 }
 
@@ -72,7 +85,9 @@ impl Msg for GetCapabilities {
 
     const SPDM_CODE: u8 = 0xE1;
 
-    fn write_body(&self, w: &mut Writer) -> Result<usize, WriteError> {
+    type WriteError = BufferFullError;
+
+    fn write_body(&self, w: &mut Writer) -> Result<usize, BufferFullError> {
         w.put_reserved(3)?;
         w.put(self.ct_exponent)?;
         w.put_reserved(2)?;
@@ -81,15 +96,16 @@ impl Msg for GetCapabilities {
 }
 
 impl GetCapabilities {
-    pub fn parse_body(buf: &[u8]) -> Result<GetCapabilities, ReadError> {
-        let mut reader = Reader::new(Self::NAME, buf);
+    pub fn parse_body(
+        buf: &[u8],
+    ) -> Result<GetCapabilities, ParseGetCapabilitiesError> {
+        let mut reader = Reader::new(buf);
         reader.skip_reserved(3)?;
         let ct_exponent = reader.get_byte()?;
         reader.skip_reserved(2)?;
         let flags = reader.get_u32()?;
-        let flags = ReqFlags::from_bits(flags).ok_or_else(|| {
-            ReadError::new(Self::NAME, ReadErrorKind::InvalidBitsSet)
-        })?;
+        let flags = ReqFlags::from_bits(flags)
+            .ok_or_else(|| ParseGetCapabilitiesError::InvalidBitsSet)?;
         Ok(GetCapabilities { ct_exponent, flags })
     }
 }
@@ -118,10 +134,14 @@ bitflags! {
     }
 }
 
+/// The capability failed to parse
+#[derive(Debug, PartialEq)]
+pub struct ParseRspCapabilityError;
+
 // We only allow strings for fields we want the user to configure, excluding
 // things like `PSK_CAP_MASK`.impl FromStr for RspFlags {
 impl FromStr for RspFlags {
-    type Err = ReadError;
+    type Err = ParseRspCapabilityError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let flag = match s {
             "CACHE_CAP" => RspFlags::CACHE_CAP,
@@ -141,13 +161,22 @@ impl FromStr for RspFlags {
             }
             "PUB_KEY_ID_CAP" => RspFlags::PUB_KEY_ID_CAP,
             _ => {
-                return Err(ReadError::new(
-                    "CAPABILITIES",
-                    ReadErrorKind::UnexpectedValue,
-                ))
+                return Err(ParseRspCapabilityError);
             }
         };
         Ok(flag)
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum ParseCapabilitiesError {
+    InvalidBitsSet,
+    Read(ReadError),
+}
+
+impl From<ReadError> for ParseCapabilitiesError {
+    fn from(e: ReadError) -> Self {
+        ParseCapabilitiesError::Read(e)
     }
 }
 
@@ -164,7 +193,9 @@ impl Msg for Capabilities {
 
     const SPDM_CODE: u8 = 0x61;
 
-    fn write_body(&self, w: &mut Writer) -> Result<usize, WriteError> {
+    type WriteError = BufferFullError;
+
+    fn write_body(&self, w: &mut Writer) -> Result<usize, BufferFullError> {
         w.put_reserved(3)?;
         w.put(self.ct_exponent)?;
         w.put_reserved(2)?;
@@ -173,15 +204,16 @@ impl Msg for Capabilities {
 }
 
 impl Capabilities {
-    pub fn parse_body(buf: &[u8]) -> Result<Capabilities, ReadError> {
-        let mut reader = Reader::new(Self::NAME, buf);
+    pub fn parse_body(
+        buf: &[u8],
+    ) -> Result<Capabilities, ParseCapabilitiesError> {
+        let mut reader = Reader::new(buf);
         reader.skip_reserved(3)?;
         let ct_exponent = reader.get_byte()?;
         reader.skip_reserved(2)?;
         let flags = reader.get_u32()?;
-        let flags = RspFlags::from_bits(flags).ok_or_else(|| {
-            ReadError::new(Self::NAME, ReadErrorKind::InvalidBitsSet)
-        })?;
+        let flags = RspFlags::from_bits(flags)
+            .ok_or_else(|| ParseCapabilitiesError::InvalidBitsSet)?;
         Ok(Capabilities { ct_exponent, flags })
     }
 }

--- a/src/msgs/certificates.rs
+++ b/src/msgs/certificates.rs
@@ -7,9 +7,7 @@ use core::cmp::PartialEq;
 use crate::config::{MAX_CERT_CHAIN_DEPTH, MAX_CERT_CHAIN_SIZE};
 
 use super::common::DigestSize;
-use super::encoding::{
-    ReadError, ReadErrorKind, Reader, WriteError, WriteErrorKind, Writer,
-};
+use super::encoding::{BufferFullError, ReadError, Reader, Writer};
 use super::Msg;
 
 /// A request for a certificate portion in a given slot
@@ -32,7 +30,9 @@ impl Msg for GetCertificate {
 
     const SPDM_CODE: u8 = 0x82;
 
-    fn write_body(&self, w: &mut Writer) -> Result<usize, WriteError> {
+    type WriteError = BufferFullError;
+
+    fn write_body(&self, w: &mut Writer) -> Result<usize, BufferFullError> {
         w.put(self.slot)?;
         w.put_reserved(1)?;
         w.put_u16(self.offset)?;
@@ -42,7 +42,7 @@ impl Msg for GetCertificate {
 
 impl GetCertificate {
     pub fn parse_body(buf: &[u8]) -> Result<GetCertificate, ReadError> {
-        let mut r = Reader::new(Self::NAME, buf);
+        let mut r = Reader::new(buf);
         let slot = r.get_byte()?;
         r.skip_reserved(1)?;
         let offset = r.get_u16()?;
@@ -68,7 +68,9 @@ impl Msg for Certificate {
 
     const SPDM_CODE: u8 = 0x02;
 
-    fn write_body(&self, w: &mut Writer) -> Result<usize, WriteError> {
+    type WriteError = BufferFullError;
+
+    fn write_body(&self, w: &mut Writer) -> Result<usize, BufferFullError> {
         w.put(self.slot)?;
         w.put_reserved(1)?;
         w.put_u16(self.portion_length)?;
@@ -77,17 +79,28 @@ impl Msg for Certificate {
     }
 }
 
+#[derive(Debug, PartialEq)]
+pub enum ParseCertificateError {
+    TooLarge,
+    Read(ReadError),
+}
+
+impl From<ReadError> for ParseCertificateError {
+    fn from(e: ReadError) -> Self {
+        ParseCertificateError::Read(e)
+    }
+}
+
 impl Certificate {
-    pub fn parse_body(buf: &[u8]) -> Result<Certificate, ReadError> {
-        let mut r = Reader::new(Self::NAME, buf);
+    pub fn parse_body(
+        buf: &[u8],
+    ) -> Result<Certificate, ParseCertificateError> {
+        let mut r = Reader::new(buf);
         let slot = r.get_byte()?;
         r.skip_reserved(1)?;
         let portion_length = r.get_u16()?;
         if portion_length as usize > MAX_CERT_CHAIN_SIZE {
-            return Err(ReadError::new(
-                Self::NAME,
-                ReadErrorKind::ImplementationLimitReached,
-            ));
+            return Err(ParseCertificateError::TooLarge);
         }
         let remainder_length = r.get_u16()?;
         let mut cert_chain = [0u8; MAX_CERT_CHAIN_SIZE];
@@ -130,10 +143,34 @@ impl<'a> PartialEq for CertificateChain<'a> {
 
 impl<'a> Eq for CertificateChain<'a> {}
 
-/// Indicates that there is no more room for intermediate certs in a
-/// `CertificateChain`.
 #[derive(Debug)]
-pub struct Full {}
+pub struct MaxCertChainDepthExceededError;
+
+#[derive(Debug, PartialEq)]
+pub enum WriteCertificateChainError {
+    MaxSizeExceeded,
+    BufferFull,
+}
+
+impl From<BufferFullError> for WriteCertificateChainError {
+    fn from(_: BufferFullError) -> Self {
+        WriteCertificateChainError::BufferFull
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum ParseCertificateChainError {
+    BadDerEncoding,
+    LengthMismatch,
+    MaxDepthExceeded,
+    Read(ReadError),
+}
+
+impl From<ReadError> for ParseCertificateChainError {
+    fn from(e: ReadError) -> Self {
+        ParseCertificateChainError::Read(e)
+    }
+}
 
 impl<'a> CertificateChain<'a> {
     /// Create a new certificate chain with no intermediate certificates
@@ -171,9 +208,9 @@ impl<'a> CertificateChain<'a> {
     pub fn append_intermediate_cert(
         &mut self,
         cert: &'a [u8],
-    ) -> Result<(), Full> {
+    ) -> Result<(), MaxCertChainDepthExceededError> {
         if self.num_intermediate_certs as usize == MAX_CERT_CHAIN_DEPTH {
-            return Err(Full {});
+            return Err(MaxCertChainDepthExceededError);
         }
         self.intermediate_certs[self.num_intermediate_certs as usize] = cert;
         self.num_intermediate_certs += 1;
@@ -181,17 +218,17 @@ impl<'a> CertificateChain<'a> {
     }
 
     /// Serialize a certificate chain via a Writer
-    pub fn write(&self, w: &mut Writer) -> Result<usize, WriteError> {
+    pub fn write(
+        &self,
+        w: &mut Writer,
+    ) -> Result<usize, WriteCertificateChainError> {
         let length = 4
             + self.root_hash.len()
             + (0..self.num_intermediate_certs as usize)
                 .fold(0, |acc, i| acc + self.intermediate_certs[i].len())
             + self.leaf_cert.len();
         if length > 65535 {
-            return Err(WriteError::new(
-                "CERTFICATE",
-                WriteErrorKind::InvalidRange("CertificateChain (length)"),
-            ));
+            return Err(WriteCertificateChainError::MaxSizeExceeded);
         }
         w.put_u16(length as u16)?;
         w.put_reserved(2)?;
@@ -199,7 +236,8 @@ impl<'a> CertificateChain<'a> {
         for i in 0..self.num_intermediate_certs as usize {
             w.extend(self.intermediate_certs[i])?;
         }
-        w.extend(self.leaf_cert)
+        w.extend(self.leaf_cert)?;
+        Ok(w.offset())
     }
 
     /// Deserialize a CertificateChain into `buf` given `digest_size`.
@@ -208,11 +246,11 @@ impl<'a> CertificateChain<'a> {
     pub fn parse(
         buf: &'a [u8],
         digest_size: DigestSize,
-    ) -> Result<CertificateChain<'a>, ReadError> {
-        let mut r = Reader::new("CERTFICATE", buf);
+    ) -> Result<CertificateChain<'a>, ParseCertificateChainError> {
+        let mut r = Reader::new(buf);
         let length = r.get_u16()?;
         if length as usize != buf.len() {
-            return Err(Self::err_unexpected());
+            return Err(ParseCertificateChainError::LengthMismatch);
         }
         r.skip_reserved(2)?;
         let offset = r.byte_offset();
@@ -227,17 +265,14 @@ impl<'a> CertificateChain<'a> {
             let offset = r.byte_offset();
             let (length, header_size) = Self::read_cert_size(&mut r)?;
             if length > r.remaining() {
-                return Err(Self::err_unexpected());
+                return Err(ParseCertificateChainError::LengthMismatch);
             }
             if length == r.remaining() {
                 // we found the end entity cert
                 break offset;
             }
             if num_intermediate_certs as usize == MAX_CERT_CHAIN_DEPTH {
-                return Err(ReadError::new(
-                    "CERTFICATE",
-                    ReadErrorKind::ImplementationLimitReached,
-                ));
+                return Err(ParseCertificateChainError::MaxDepthExceeded);
             }
             let end = offset + length + header_size;
             intermediate_certs[num_intermediate_certs as usize] =
@@ -257,10 +292,6 @@ impl<'a> CertificateChain<'a> {
         })
     }
 
-    fn err_unexpected() -> ReadError {
-        return ReadError::new("CERTFICATE", ReadErrorKind::UnexpectedValue);
-    }
-
     // Read the size of the cert from the DER encoded header along with the
     // number of bytes read (2 - 4).
     //
@@ -268,7 +299,9 @@ impl<'a> CertificateChain<'a> {
     // is encoded in the seven remaining bits of that byte. Otherwise, those
     // seven bits represent the number of bytes used to encode the length in big
     // endian format.
-    fn read_cert_size(r: &mut Reader) -> Result<(usize, usize), ReadError> {
+    fn read_cert_size(
+        r: &mut Reader,
+    ) -> Result<(usize, usize), ParseCertificateChainError> {
         // Skip the sequence byte
         assert_eq!(r.get_byte()?, 0x30);
 
@@ -277,7 +310,7 @@ impl<'a> CertificateChain<'a> {
             0x81 => {
                 let n = r.get_byte()?;
                 if n < 128 {
-                    return Err(Self::err_unexpected());
+                    return Err(ParseCertificateChainError::BadDerEncoding);
                 }
                 (n.into(), 3)
             }
@@ -286,12 +319,12 @@ impl<'a> CertificateChain<'a> {
                 let low = r.get_byte()? as usize;
                 let n = (high << 8) | low;
                 if n < 256 {
-                    return Err(Self::err_unexpected());
+                    return Err(ParseCertificateChainError::BadDerEncoding);
                 }
                 (n.into(), 4)
             }
             _ => {
-                return Err(Self::err_unexpected());
+                return Err(ParseCertificateChainError::BadDerEncoding);
             }
         };
         Ok(pair)
@@ -352,7 +385,7 @@ mod tests {
         let cert_chain = CertificateChain::new(&fake_hash, &der);
 
         let mut buf = [0u8; 1024];
-        let mut w = Writer::new("test", &mut buf);
+        let mut w = Writer::new(&mut buf);
         let size = cert_chain.write(&mut w).unwrap();
 
         let digest_size = DigestSize::try_from(32).unwrap();
@@ -391,7 +424,7 @@ mod tests {
         cert_chain.append_intermediate_cert(&der_inter2).unwrap();
 
         let mut buf = [0u8; 2048];
-        let mut w = Writer::new("test", &mut buf);
+        let mut w = Writer::new(&mut buf);
         let size = cert_chain.write(&mut w).unwrap();
 
         let digest_size = DigestSize::try_from(32).unwrap();

--- a/src/msgs/digest.rs
+++ b/src/msgs/digest.rs
@@ -5,7 +5,7 @@
 use core::cmp::PartialEq;
 
 use super::common::{DigestBuf, DigestSize};
-use super::encoding::{ReadError, Reader, WriteError, Writer};
+use super::encoding::{BufferFullError, ReadError, Reader, Writer};
 use super::Msg;
 
 use crate::config::NUM_SLOTS;
@@ -26,14 +26,16 @@ impl Msg for GetDigests {
 
     const SPDM_CODE: u8 = 0x81;
 
-    fn write_body(&self, w: &mut Writer) -> Result<usize, WriteError> {
+    type WriteError = BufferFullError;
+
+    fn write_body(&self, w: &mut Writer) -> Result<usize, BufferFullError> {
         w.put_reserved(2)
     }
 }
 
 impl GetDigests {
     pub fn parse_body(buf: &[u8]) -> Result<GetDigests, ReadError> {
-        let mut reader = Reader::new(Self::NAME, buf);
+        let mut reader = Reader::new(buf);
         reader.skip_reserved(2)?;
         Ok(GetDigests {})
     }
@@ -56,7 +58,9 @@ impl Msg for Digests {
 
     const SPDM_CODE: u8 = 0x01;
 
-    fn write_body(&self, w: &mut Writer) -> Result<usize, WriteError> {
+    type WriteError = BufferFullError;
+
+    fn write_body(&self, w: &mut Writer) -> Result<usize, BufferFullError> {
         w.put_reserved(1)?;
         w.put(self.slot_mask)?;
         self.write_digests(w)
@@ -69,7 +73,7 @@ impl Digests {
         digest_size: DigestSize,
         buf: &[u8],
     ) -> Result<Digests, ReadError> {
-        let mut r = Reader::new(Self::NAME, buf);
+        let mut r = Reader::new(buf);
         r.skip_reserved(1)?;
         let slot_mask = r.get_byte()?;
         Self::read_digests(slot_mask, digest_size, &mut r)
@@ -99,7 +103,7 @@ impl Digests {
     // slot k is the kth bit set in `self.slot_mask`.
     //
     // We loop over the ones from low to high in `self.slot_mask`.
-    fn write_digests(&self, w: &mut Writer) -> Result<usize, WriteError> {
+    fn write_digests(&self, w: &mut Writer) -> Result<usize, BufferFullError> {
         let mut bits = self.slot_mask;
         let mut offset = w.offset();
         let mut k = bits.trailing_zeros() as usize;

--- a/src/msgs/encoding.rs
+++ b/src/msgs/encoding.rs
@@ -3,81 +3,27 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use core::convert::TryInto;
-use core::fmt::{self, Display, Formatter};
 
-/// An error returned by a `Writer` when serialization fails.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct WriteError {
-    pub msg: &'static str,
-    pub kind: WriteErrorKind,
-}
-
-impl WriteError {
-    pub fn new(msg: &'static str, kind: WriteErrorKind) -> WriteError {
-        WriteError { msg, kind }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum WriteErrorKind {
-    /// The buffer being written into is out of space
-    BufferFull,
-
-    /// The integer value for the given field is not within the expected range
-    InvalidRange(&'static str),
-
-    /// A value written for the given field was incorrect
-    UnexpectedValue(&'static str),
-
-    /// A value for the given field is too large
-    TooLarge { field: &'static str, max_size: usize, actual_size: usize },
-}
-
-impl Display for WriteErrorKind {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            WriteErrorKind::BufferFull => write!(f, "buffer full"),
-            WriteErrorKind::InvalidRange(field_name) => {
-                write!(f, "invalid range for field {}", field_name)
-            }
-            WriteErrorKind::UnexpectedValue(field_name) => {
-                write!(f, "unexpected value for field {}", field_name)
-            }
-            WriteErrorKind::TooLarge { field, max_size, actual_size } => {
-                write!(
-                    f,
-                    "too large value for field {}: max size={}, actual_size={}",
-                    field, max_size, actual_size
-                )
-            }
-        }
-    }
-}
-
-impl Display for WriteError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "failed to serialize msg {}: {}", self.msg, self.kind)
-    }
-}
+#[derive(Debug, PartialEq, Eq)]
+pub struct BufferFullError;
 
 /// The mechanism used for serializing SPDM messages
 pub struct Writer<'a> {
-    msg: &'static str,
     buf: &'a mut [u8],
     offset: usize,
 }
 
 impl<'a> Writer<'a> {
-    pub fn new(msg: &'static str, buf: &'a mut [u8]) -> Writer<'a> {
-        Writer { msg, buf, offset: 0 }
+    pub fn new(buf: &'a mut [u8]) -> Writer<'a> {
+        Writer { buf, offset: 0 }
     }
 
     /// Append a byte onto the buffer.
     ///
     /// Return the amount of the buffer used or an error if the buffer is full.
-    pub fn put(&mut self, value: u8) -> Result<usize, WriteError> {
+    pub fn put(&mut self, value: u8) -> Result<usize, BufferFullError> {
         if self.is_full() {
-            Err(WriteError::new(self.msg, WriteErrorKind::BufferFull))
+            Err(BufferFullError)
         } else {
             self.buf[self.offset] = value;
             self.offset += 1;
@@ -89,7 +35,10 @@ impl<'a> Writer<'a> {
     ///
     /// This is a first class method because the protocol has so many
     /// reserved bytes.
-    pub fn put_reserved(&mut self, num_bytes: u8) -> Result<usize, WriteError> {
+    pub fn put_reserved(
+        &mut self,
+        num_bytes: u8,
+    ) -> Result<usize, BufferFullError> {
         for _ in 0..num_bytes {
             self.put(0)?;
         }
@@ -97,7 +46,7 @@ impl<'a> Writer<'a> {
     }
 
     // Write a u16 in little endian byte order
-    pub fn put_u16(&mut self, num: u16) -> Result<usize, WriteError> {
+    pub fn put_u16(&mut self, num: u16) -> Result<usize, BufferFullError> {
         let buf = num.to_le_bytes();
         for i in 0..2 {
             self.put(buf[i])?;
@@ -106,7 +55,7 @@ impl<'a> Writer<'a> {
     }
 
     // Write a u32 in little-endian byte order
-    pub fn put_u32(&mut self, num: u32) -> Result<usize, WriteError> {
+    pub fn put_u32(&mut self, num: u32) -> Result<usize, BufferFullError> {
         let buf = num.to_le_bytes();
         for i in 0..4 {
             self.put(buf[i])?;
@@ -115,9 +64,9 @@ impl<'a> Writer<'a> {
     }
 
     // Append a slice onto the buffer
-    pub fn extend(&mut self, buf: &[u8]) -> Result<usize, WriteError> {
+    pub fn extend(&mut self, buf: &[u8]) -> Result<usize, BufferFullError> {
         if buf.len() > self.remaining() {
-            Err(WriteError::new(self.msg, WriteErrorKind::BufferFull))
+            Err(BufferFullError)
         } else {
             let end = self.offset + buf.len();
             self.buf[self.offset..end].copy_from_slice(buf);
@@ -142,10 +91,12 @@ impl<'a> Writer<'a> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ReadErrorKind {
-    Header,
-    Empty,
+#[derive(Debug, PartialEq, Eq)]
+pub enum ReadError {
+    /// There is no more data left in the read buffer
+    BufferEmpty,
+
+    /// Reserved bytes in messages must always be 0
     ReservedByteNotZero,
 
     /// An attempt to read one or more bytes not on a byte boundary
@@ -157,87 +108,27 @@ pub enum ReadErrorKind {
     /// An attempt to convert a type via core::convert::TryInto failed. This
     /// should *never* happen.
     TypeConversionFailed,
-
-    /// Bits not defined by bitflags were incorrectly set
-    InvalidBitsSet,
-
-    // More than one bit was set in a selection
-    TooManyBitsSet,
-
-    /// SPDM limits the values of some message fields
-    SpdmLimitReached,
-
-    /// Our implementation limits the value of some message fields
-    ImplementationLimitReached,
-
-    // A field in a SPDM message has an unexpected value
-    UnexpectedValue,
-}
-
-impl ReadErrorKind {
-    fn as_str(&self) -> &'static str {
-        match self {
-            ReadErrorKind::Header => "invalid header",
-            ReadErrorKind::Empty => "read buffer is empty",
-            ReadErrorKind::ReservedByteNotZero => {
-                "reserved byte was not set to 0"
-            }
-            ReadErrorKind::Unaligned => {
-                "byte read attempted on a non-byte boundary"
-            }
-            ReadErrorKind::TooManyBits => "attempt to read more than 7 bits",
-            ReadErrorKind::TypeConversionFailed => "type conversion failed",
-            ReadErrorKind::InvalidBitsSet => "invalid bits set",
-            ReadErrorKind::TooManyBitsSet => "more than one bit set",
-            ReadErrorKind::SpdmLimitReached => "SPDM protocol limit exceeded",
-            ReadErrorKind::ImplementationLimitReached => {
-                "implementation limit
-exceeded"
-            }
-            ReadErrorKind::UnexpectedValue => "unexpected value",
-        }
-    }
-}
-
-/// An error returned by a Reader when deserialization fails
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ReadError {
-    pub msg: &'static str,
-    pub kind: ReadErrorKind,
-}
-
-impl ReadError {
-    pub fn new(msg: &'static str, kind: ReadErrorKind) -> ReadError {
-        ReadError { msg, kind }
-    }
-}
-
-impl Display for ReadError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "failed to deserialize {}: {}", self.msg, self.kind.as_str())
-    }
 }
 
 /// The mechanism used  for deserializing SPDM messages
 pub struct Reader<'a> {
-    msg: &'static str,
     buf: &'a [u8],
     byte_offset: usize,
     bit_offset: u8,
 }
 
 impl<'a> Reader<'a> {
-    pub fn new(msg: &'static str, buf: &'a [u8]) -> Reader<'a> {
-        Reader { msg, buf, byte_offset: 0, bit_offset: 0 }
+    pub fn new(buf: &'a [u8]) -> Reader<'a> {
+        Reader { buf, byte_offset: 0, bit_offset: 0 }
     }
 
     /// Return the next byte in the buffer and advance the cursor.
     pub fn get_byte(&mut self) -> Result<u8, ReadError> {
         if !self.is_aligned() {
-            return Err(self.err(ReadErrorKind::Unaligned));
+            return Err(ReadError::Unaligned);
         }
         if self.is_empty() {
-            return Err(self.err(ReadErrorKind::Empty));
+            return Err(ReadError::BufferEmpty);
         }
         let b = self.buf[self.byte_offset];
         self.byte_offset += 1;
@@ -251,7 +142,7 @@ impl<'a> Reader<'a> {
         for _ in 0..num_bytes {
             let byte = self.get_byte()?;
             if byte != 0 {
-                return Err(self.err(ReadErrorKind::ReservedByteNotZero));
+                return Err(ReadError::ReservedByteNotZero);
             }
         }
         Ok(())
@@ -272,17 +163,17 @@ impl<'a> Reader<'a> {
     // The read does not have to be aligned.
     pub fn get_bits(&mut self, count: u8) -> Result<u8, ReadError> {
         if self.is_empty() {
-            return Err(ReadError::new(self.msg, ReadErrorKind::Empty));
+            return Err(ReadError::BufferEmpty);
         }
         if count > 7 {
-            return Err(ReadError::new(self.msg, ReadErrorKind::TooManyBits));
+            return Err(ReadError::TooManyBits);
         }
         let mut new_bit_offset = self.bit_offset + count;
         if new_bit_offset >= 8 {
             let new_byte_offset = self.byte_offset + 1;
             new_bit_offset = new_bit_offset - 8;
             if new_byte_offset == self.buf.len() && new_bit_offset != 0 {
-                Err(ReadError::new(self.msg, ReadErrorKind::Empty))
+                Err(ReadError::BufferEmpty)
             } else {
                 // Bits from first byte become low order bits in returned byte
                 let mut b = self.buf[self.byte_offset] >> self.bit_offset;
@@ -319,15 +210,15 @@ impl<'a> Reader<'a> {
     /// This only works on aligned reads.
     pub fn get_u16(&mut self) -> Result<u16, ReadError> {
         if !self.is_aligned() {
-            return Err(self.err(ReadErrorKind::Unaligned));
+            return Err(ReadError::Unaligned);
         }
         if self.remaining() < 2 {
-            return Err(self.err(ReadErrorKind::Empty));
+            return Err(ReadError::BufferEmpty);
         }
         let pos = self.byte_offset;
         let buf: &[u8; 2] = &self.buf[pos..pos + 2]
             .try_into()
-            .map_err(|_| self.err(ReadErrorKind::TypeConversionFailed))?;
+            .map_err(|_| ReadError::TypeConversionFailed)?;
         self.byte_offset += 2;
         Ok(u16::from_le_bytes(*buf))
     }
@@ -343,11 +234,11 @@ impl<'a> Reader<'a> {
         buf: &mut [u8],
     ) -> Result<(), ReadError> {
         if !self.is_aligned() {
-            return Err(self.err(ReadErrorKind::Unaligned));
+            return Err(ReadError::Unaligned);
         }
 
         if self.remaining() < size {
-            return Err(self.err(ReadErrorKind::Empty));
+            return Err(ReadError::BufferEmpty);
         }
 
         let start = self.byte_offset;
@@ -361,15 +252,15 @@ impl<'a> Reader<'a> {
     /// This only works on aligned reads.
     pub fn get_u32(&mut self) -> Result<u32, ReadError> {
         if !self.is_aligned() {
-            return Err(self.err(ReadErrorKind::Unaligned));
+            return Err(ReadError::Unaligned);
         }
         if self.remaining() < 4 {
-            return Err(self.err(ReadErrorKind::Empty));
+            return Err(ReadError::BufferEmpty);
         }
         let pos = self.byte_offset;
         let buf: &[u8; 4] = &self.buf[pos..pos + 4]
             .try_into()
-            .map_err(|_| self.err(ReadErrorKind::TypeConversionFailed))?;
+            .map_err(|_| ReadError::TypeConversionFailed)?;
         self.byte_offset += 4;
         Ok(u32::from_le_bytes(*buf))
     }
@@ -393,10 +284,6 @@ impl<'a> Reader<'a> {
     pub fn is_aligned(&self) -> bool {
         self.bit_offset == 0
     }
-
-    fn err(&self, kind: ReadErrorKind) -> ReadError {
-        ReadError::new(self.msg, kind)
-    }
 }
 
 #[cfg(test)]
@@ -406,7 +293,7 @@ mod tests {
     #[test]
     fn read_by_4_bits() {
         let buf = [0xF0, 0xF0];
-        let mut reader = Reader::new("TEST_MSG", &buf);
+        let mut reader = Reader::new(&buf);
         assert_eq!(0x00, reader.get_bits(4).unwrap());
         assert!(!reader.is_aligned());
         assert!(!reader.is_empty());
@@ -427,7 +314,7 @@ mod tests {
     #[test]
     fn read_by_3_bits() {
         let buf = [0xF0, 0xF0];
-        let mut reader = Reader::new("TEST_MSG", &buf);
+        let mut reader = Reader::new(&buf);
 
         // 0b000
         assert_eq!(0x00, reader.get_bits(3).unwrap());
@@ -463,7 +350,7 @@ mod tests {
     #[test]
     fn read_by_gt_8_bits_fails() {
         let buf = [0xF0, 0xF0];
-        let mut reader = Reader::new("TEST_MSG", &buf);
+        let mut reader = Reader::new(&buf);
         assert!(reader.get_bits(8).is_err());
         assert!(reader.get_bits(9).is_err());
         assert!(reader.get_bits(10).is_err());
@@ -472,7 +359,7 @@ mod tests {
     #[test]
     fn get_bit_by_bit() {
         let buf = [0xF0, 0xF0];
-        let mut reader = Reader::new("TEST_MSG", &buf);
+        let mut reader = Reader::new(&buf);
         for i in 0..4 {
             if i % 2 == 0 {
                 assert!(reader.is_aligned());

--- a/src/msgs/measurements.rs
+++ b/src/msgs/measurements.rs
@@ -4,9 +4,7 @@
 
 use super::algorithms::MeasurementSpec;
 use super::common::{Nonce, OpaqueData, SignatureBuf};
-use super::encoding::{
-    ReadError, ReadErrorKind, Reader, WriteError, WriteErrorKind, Writer,
-};
+use super::encoding::{BufferFullError, ReadError, Reader, Writer};
 use super::Msg;
 use crate::config;
 
@@ -64,31 +62,29 @@ impl From<u8> for MeasurementIndex {
     }
 }
 
+#[derive(Debug)]
+pub enum WriteMeasurementIndexError {
+    InvalidImplementationDefinedIndex,
+    InvalidReservedIndex,
+}
+
 impl TryFrom<&MeasurementIndex> for u8 {
-    type Error = WriteError;
+    type Error = WriteMeasurementIndexError;
     fn try_from(val: &MeasurementIndex) -> Result<Self, Self::Error> {
         let index = match val {
             MeasurementIndex::TotalNumberOfMeasurementsAvailable => 0,
             MeasurementIndex::AllMeasurements => 0xFF,
             MeasurementIndex::ImplementationDefined(index) => {
                 if *index < 0x1 || *index > 0xEF {
-                    return Err(WriteError::new(
-                        "GET_MEASUREMENTS",
-                        WriteErrorKind::InvalidRange(
-                            "MeasurementIndex (ImplementationDefined)",
-                        ),
-                    ));
+                    return Err(WriteMeasurementIndexError::InvalidImplementationDefinedIndex);
                 }
                 *index
             }
             MeasurementIndex::Reserved(index) => {
                 if *index < 0xF0 || *index > 0xFC {
-                    return Err(WriteError::new(
-                        "GET_MEASUREMENTS",
-                        WriteErrorKind::InvalidRange(
-                            "MeasurementIndex (Reserved)",
-                        ),
-                    ));
+                    return Err(
+                        WriteMeasurementIndexError::InvalidReservedIndex,
+                    );
                 }
                 *index
             }
@@ -96,6 +92,37 @@ impl TryFrom<&MeasurementIndex> for u8 {
             MeasurementIndex::DeviceMode => 0xFE,
         };
         Ok(index)
+    }
+}
+
+#[derive(Debug)]
+pub enum WriteGetMeasurementsError {
+    BufferFull,
+    MeasurementIndex(WriteMeasurementIndexError),
+}
+
+impl From<BufferFullError> for WriteGetMeasurementsError {
+    fn from(_: BufferFullError) -> Self {
+        WriteGetMeasurementsError::BufferFull
+    }
+}
+
+impl From<WriteMeasurementIndexError> for WriteGetMeasurementsError {
+    fn from(e: WriteMeasurementIndexError) -> Self {
+        WriteGetMeasurementsError::MeasurementIndex(e)
+    }
+}
+
+#[derive(Debug)]
+pub enum ParseGetMeasurementsError {
+    ReservedBitsNotZero,
+    MaxSlotNumberExceeded,
+    Read(ReadError),
+}
+
+impl From<ReadError> for ParseGetMeasurementsError {
+    fn from(e: ReadError) -> Self {
+        ParseGetMeasurementsError::Read(e)
     }
 }
 
@@ -121,18 +148,13 @@ impl GetMeasurements {
         attributes: RequestAttributes,
         index: MeasurementIndex,
         slot_id: u8,
-    ) -> Result<GetMeasurements, WriteError> {
-        if (slot_id as usize) >= config::NUM_SLOTS {
-            return Err(WriteError::new(
-                Self::NAME,
-                WriteErrorKind::InvalidRange("slot_id"),
-            ));
-        }
+    ) -> GetMeasurements {
+        assert!((slot_id as usize) < config::NUM_SLOTS);
         let mut nonce = None;
         if attributes.signature_requested {
             nonce = Some(Nonce::new());
         }
-        Ok(GetMeasurements { attributes, index, slot_id, nonce })
+        GetMeasurements { attributes, index, slot_id, nonce }
     }
 }
 
@@ -141,7 +163,12 @@ impl Msg for GetMeasurements {
     const SPDM_VERSION: u8 = 0x12;
     const SPDM_CODE: u8 = 0xE0;
 
-    fn write_body(&self, w: &mut Writer) -> Result<usize, WriteError> {
+    type WriteError = WriteGetMeasurementsError;
+
+    fn write_body(
+        &self,
+        w: &mut Writer,
+    ) -> Result<usize, WriteGetMeasurementsError> {
         w.put((&self.attributes).into())?;
         w.put((&self.index).try_into()?)?;
         if self.attributes.signature_requested {
@@ -153,8 +180,10 @@ impl Msg for GetMeasurements {
 }
 
 impl GetMeasurements {
-    pub fn parse_body(buf: &[u8]) -> Result<GetMeasurements, ReadError> {
-        let mut r = Reader::new(Self::NAME, buf);
+    pub fn parse_body(
+        buf: &[u8],
+    ) -> Result<GetMeasurements, ParseGetMeasurementsError> {
+        let mut r = Reader::new(buf);
         let attributes = RequestAttributes {
             signature_requested: r.get_bit()? == 1,
             raw_bit_stream_requested: r.get_bit()? == 1,
@@ -162,10 +191,7 @@ impl GetMeasurements {
 
         // Skip over next 6 reserved bits
         if r.get_bits(6)? != 0 {
-            return Err(ReadError::new(
-                Self::NAME,
-                ReadErrorKind::InvalidBitsSet,
-            ));
+            return Err(ParseGetMeasurementsError::ReservedBitsNotZero);
         }
 
         let index = r.get_byte()?.into();
@@ -175,10 +201,7 @@ impl GetMeasurements {
             nonce = Some(Nonce::read(&mut r)?);
             slot_id = r.get_byte()?;
             if (slot_id as usize) >= config::NUM_SLOTS {
-                return Err(ReadError::new(
-                    Self::NAME,
-                    ReadErrorKind::UnexpectedValue,
-                ));
+                return Err(ParseGetMeasurementsError::MaxSlotNumberExceeded);
             }
         }
 
@@ -311,8 +334,7 @@ mod tests {
             },
             MeasurementIndex::AllMeasurements,
             0,
-        )
-        .unwrap();
+        );
 
         assert_eq!(37, msg.write(&mut buf).unwrap());
 
@@ -336,21 +358,6 @@ mod tests {
     }
 
     #[test]
-    fn get_measurements_constructor_err() {
-        // slot_id is outside valid range
-        let slot_id = 9;
-        assert!(GetMeasurements::new(
-            RequestAttributes {
-                signature_requested: false,
-                raw_bit_stream_requested: false
-            },
-            MeasurementIndex::AllMeasurements,
-            slot_id
-        )
-        .is_err())
-    }
-
-    #[test]
     fn get_measurements_write_err() {
         let mut buf = [0u8; 64];
         let mut msg = GetMeasurements::new(
@@ -361,8 +368,7 @@ mod tests {
             // 0x5 is not a reserved bit
             MeasurementIndex::Reserved(0x5),
             0,
-        )
-        .unwrap();
+        );
 
         assert!(msg.write(&mut buf).is_err());
 
@@ -386,8 +392,7 @@ mod tests {
             // 0x5 is not a reserved bit
             MeasurementIndex::DeviceMode,
             0,
-        )
-        .unwrap();
+        );
 
         assert_eq!(37, msg.write(&mut buf).unwrap());
 

--- a/src/msgs/version.rs
+++ b/src/msgs/version.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use super::encoding::{ReadError, ReadErrorKind, Reader, WriteError, Writer};
+use super::encoding::{BufferFullError, ReadError, Reader, Writer};
 use super::Msg;
 
 /// Request the SPDM version in use at the responder.
@@ -17,14 +17,16 @@ impl Msg for GetVersion {
 
     const SPDM_CODE: u8 = 0x84;
 
-    fn write_body(&self, w: &mut Writer) -> Result<usize, WriteError> {
+    type WriteError = BufferFullError;
+
+    fn write_body(&self, w: &mut Writer) -> Result<usize, BufferFullError> {
         w.put_reserved(2)
     }
 }
 
 impl GetVersion {
     pub fn parse_body(buf: &[u8]) -> Result<GetVersion, ReadError> {
-        let mut reader = Reader::new(Self::NAME, buf);
+        let mut reader = Reader::new(buf);
         reader.skip_reserved(2)?;
         Ok(GetVersion {})
     }
@@ -81,7 +83,9 @@ impl Msg for Version {
 
     const SPDM_CODE: u8 = 0x04;
 
-    fn write_body(&self, w: &mut Writer) -> Result<usize, WriteError> {
+    type WriteError = BufferFullError;
+
+    fn write_body(&self, w: &mut Writer) -> Result<usize, BufferFullError> {
         // Reserved bytes
         w.put(0)?;
         w.put(0)?;
@@ -98,19 +102,31 @@ impl Msg for Version {
     }
 }
 
+#[derive(Debug, PartialEq)]
+pub enum ParseVersionError {
+    /// More versions were received than there is space to handle
+    TooManyVersionsReceived,
+
+    /// Error processing input
+    Read(ReadError),
+}
+
+impl From<ReadError> for ParseVersionError {
+    fn from(e: ReadError) -> Self {
+        ParseVersionError::Read(e)
+    }
+}
+
 impl Version {
-    pub fn parse_body(buf: &[u8]) -> Result<Version, ReadError> {
-        let mut reader = Reader::new(Self::NAME, buf);
+    pub fn parse_body(buf: &[u8]) -> Result<Version, ParseVersionError> {
+        let mut reader = Reader::new(buf);
 
         reader.skip_reserved(3)?;
 
         // 1 byte number of version entries
         let num_entries = reader.get_byte()?;
         if num_entries > MAX_ALLOWED_VERSIONS {
-            return Err(ReadError::new(
-                Self::NAME,
-                ReadErrorKind::ImplementationLimitReached,
-            ));
+            return Err(ParseVersionError::TooManyVersionsReceived);
         }
 
         let mut version = Version::empty();

--- a/src/requester.rs
+++ b/src/requester.rs
@@ -38,8 +38,8 @@ use core::convert::From;
 pub fn expect<T: Msg>(buf: &[u8]) -> Result<(), RequesterError> {
     match T::parse_header(buf) {
         Ok(true) => Ok(()),
-        Ok(false) => Err(RequesterError::UnexpectedMsg {
-            expected: T::NAME,
+        Ok(false) => Err(RequesterError::UnexpectedMsgCode {
+            expected: T::SPDM_CODE,
             got: buf[0],
         }),
         Err(e) => Err(e.into()),

--- a/src/requester/error.rs
+++ b/src/requester/error.rs
@@ -2,42 +2,85 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use core::fmt::{self, Display, Formatter};
-
 use crate::crypto::pki;
-use crate::msgs::{ReadError, Version, WriteError};
+use crate::msgs::{
+    algorithms::{
+        ParseAlgorithmsError, ParseBaseAsymAlgoError, ParseBaseHashAlgoError,
+    },
+    capabilities::{ParseCapabilitiesError, ParseReqCapabilityError},
+    certificates::{ParseCertificateChainError, ParseCertificateError},
+    challenge::ParseChallengeAuthError,
+    version::ParseVersionError,
+    BufferFullError, ParseHeaderError, ReadError, Version,
+};
+
+use super::challenge::ChallengeAuthError;
 
 /// A requester specific error returned from state machine methods
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq)]
 pub enum RequesterError {
-    Write(WriteError),
+    // An error occurred when reading a message from a buffer
     Read(ReadError),
 
-    // `got` is the code. TODO: Try to map this to a message name?
-    UnexpectedMsg { expected: &'static str, got: u8 },
+    // Reading into a buffer failed because the buffer is full
+    BufferFull,
 
-    //
-    // Version related messages
-    //
-    NoSupportedVersions { received: Version },
+    // An unexpected message code was received in the header of a message
+    UnexpectedMsgCode {
+        expected: u8,
+        got: u8,
+    },
+
+    /// The responder does not support the same versions as the requester
+    NoSupportedVersions {
+        received: Version,
+    },
 
     // The responder chose an algorithm that was not a requester option
     SelectedAlgorithmNotRequested,
 
     // The challenge auth response was invalid
-    BadChallengeAuth(&'static str),
+    ChallengeAuth(ChallengeAuthError),
 
     // A certificate could not be parsed properly
+    ParseCert(ParseCertificateError),
     InvalidCert,
+
+    // An Algorithms msg could not be parsed properly
+    ParseAlgorithms(ParseAlgorithmsError),
+
+    // Parsing a base asymetric signing algorithm type from a string failed
+    ParseBaseAsymAlgo,
+
+    // Parsing a base hash algorithm type from a string failed
+    ParseBaseHashAlgo,
+
+    // Parsing a Capabilities message failed
+    ParseCapabilities,
+
+    // Parsing a capability from a string failed
+    ParseCapability,
 
     // Protocol initialization is complete and a secure session now exists.
     // The user must transition to the `RequesterSession` state.
     InitializationComplete,
+
+    // Parsing a ChallengeAuth message failed
+    ParseChallengeAuth(ParseChallengeAuthError),
+
+    // Parsing a message header failed
+    ParseHeader,
+
+    // Parsing a Version message failed
+    ParseVersion(ParseVersionError),
+
+    // Parsing a Certificate Chain failed
+    ParseCertChain(ParseCertificateChainError),
 }
 
-impl From<WriteError> for RequesterError {
-    fn from(e: WriteError) -> Self {
-        RequesterError::Write(e)
+impl From<BufferFullError> for RequesterError {
+    fn from(_: BufferFullError) -> Self {
+        RequesterError::BufferFull
     }
 }
 
@@ -53,38 +96,68 @@ impl From<pki::Error> for RequesterError {
     }
 }
 
-impl Display for RequesterError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            RequesterError::Write(e) => e.fmt(f),
-            RequesterError::Read(e) => e.fmt(f),
-            // TODO: print message name and not just code
-            RequesterError::UnexpectedMsg { expected, got } => {
-                write!(
-                    f,
-                    "unexpected msg: (expected: {}, got code: {})",
-                    expected, got
-                )
-            }
-            RequesterError::NoSupportedVersions { received } => {
-                write!(f, "no supported versions received: {:#?}", received)
-            }
-            RequesterError::SelectedAlgorithmNotRequested => {
-                write!(
-                    f,
-                    "the responder selected an algorithm that the
-requester does not support"
-                )
-            }
-            RequesterError::BadChallengeAuth(s) => {
-                write!(f, "challenge authentication failed: {}", s)
-            }
-            RequesterError::InvalidCert => {
-                write!(f, "invalid certificate")
-            }
-            RequesterError::InitializationComplete => {
-                write!(f, "initialization complete")
-            }
-        }
+impl From<ParseCertificateError> for RequesterError {
+    fn from(e: ParseCertificateError) -> Self {
+        RequesterError::ParseCert(e)
+    }
+}
+
+impl From<ParseAlgorithmsError> for RequesterError {
+    fn from(e: ParseAlgorithmsError) -> Self {
+        RequesterError::ParseAlgorithms(e)
+    }
+}
+
+impl From<ParseBaseAsymAlgoError> for RequesterError {
+    fn from(_: ParseBaseAsymAlgoError) -> Self {
+        RequesterError::ParseBaseAsymAlgo
+    }
+}
+
+impl From<ParseBaseHashAlgoError> for RequesterError {
+    fn from(_: ParseBaseHashAlgoError) -> Self {
+        RequesterError::ParseBaseHashAlgo
+    }
+}
+
+impl From<ParseCapabilitiesError> for RequesterError {
+    fn from(_: ParseCapabilitiesError) -> Self {
+        RequesterError::ParseCapabilities
+    }
+}
+
+impl From<ParseReqCapabilityError> for RequesterError {
+    fn from(_: ParseReqCapabilityError) -> Self {
+        RequesterError::ParseCapability
+    }
+}
+
+impl From<ParseChallengeAuthError> for RequesterError {
+    fn from(e: ParseChallengeAuthError) -> Self {
+        RequesterError::ParseChallengeAuth(e)
+    }
+}
+
+impl From<ParseHeaderError> for RequesterError {
+    fn from(_: ParseHeaderError) -> Self {
+        RequesterError::ParseHeader
+    }
+}
+
+impl From<ParseVersionError> for RequesterError {
+    fn from(e: ParseVersionError) -> Self {
+        RequesterError::ParseVersion(e)
+    }
+}
+
+impl From<ParseCertificateChainError> for RequesterError {
+    fn from(e: ParseCertificateChainError) -> Self {
+        RequesterError::ParseCertChain(e)
+    }
+}
+
+impl From<ChallengeAuthError> for RequesterError {
+    fn from(e: ChallengeAuthError) -> Self {
+        RequesterError::ChallengeAuth(e)
     }
 }

--- a/src/responder.rs
+++ b/src/responder.rs
@@ -236,8 +236,8 @@ macro_rules! reset_on_get_version {
 pub fn expect<T: Msg>(buf: &[u8]) -> Result<(), ResponderError> {
     match T::parse_header(buf) {
         Ok(true) => Ok(()),
-        Ok(false) => Err(ResponderError::UnexpectedMsg {
-            expected: T::NAME,
+        Ok(false) => Err(ResponderError::UnexpectedMsgCode {
+            expected: T::SPDM_CODE,
             got: buf[0],
         }),
         Err(e) => Err(e.into()),

--- a/src/responder/challenge.rs
+++ b/src/responder/challenge.rs
@@ -64,7 +64,7 @@ impl State {
         let cert_chain_digest =
             if let Some(Some(slot)) = slots.get(req_msg.slot as usize) {
                 let mut buf = [0u8; MAX_CERT_CHAIN_SIZE];
-                let mut w = Writer::new("CERTIFICATE_CHAIN", &mut buf);
+                let mut w = Writer::new(&mut buf);
                 let size = slot.cert_chain.write(&mut w)?;
 
                 // TODO: Should we fail this if the selected hash algorithm does

--- a/src/responder/version.rs
+++ b/src/responder/version.rs
@@ -18,8 +18,8 @@ impl State {
     ) -> Result<(usize, AllStates), ResponderError> {
         match GetVersion::parse_header(req) {
             Ok(true) => self.handle_get_version(req, rsp, transcript),
-            Ok(false) => Err(ResponderError::UnexpectedMsg {
-                expected: GetVersion::NAME,
+            Ok(false) => Err(ResponderError::UnexpectedMsgCode {
+                expected: GetVersion::SPDM_CODE,
                 got: req[0],
             }),
             Err(e) => Err(e.into()),

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::config::TRANSCRIPT_SIZE;
-use crate::msgs::{WriteError, WriteErrorKind};
+use crate::msgs::BufferFullError;
 
 /// A `Transcript` is used to track contigous operations for measurement
 /// purposes.
@@ -23,10 +23,10 @@ impl Transcript {
     }
 
     /// Append a serialized message onto the transcript
-    pub fn extend(&mut self, buf: &[u8]) -> Result<(), WriteError> {
+    pub fn extend(&mut self, buf: &[u8]) -> Result<(), BufferFullError> {
         let end = self.offset + buf.len();
         if end > self.buf.len() {
-            Err(WriteError::new("TRANSCRIPT", WriteErrorKind::BufferFull))
+            Err(BufferFullError)
         } else {
             self.buf[self.offset..end].copy_from_slice(buf);
             self.offset = end;

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -334,7 +334,7 @@ fn assert_digests_match_cert_chains<'a, S: Signer>(
         // Is there a digest for the given slot
         if (1 << i as u8) & digests.slot_mask != 0 {
             let mut buf = [0u8; MAX_CERT_CHAIN_SIZE];
-            let mut w = Writer::new("CERTIFICATE_CHAIN", &mut buf);
+            let mut w = Writer::new(&mut buf);
             let size = slot.as_ref().unwrap().cert_chain.write(&mut w).unwrap();
             let expected = DigestImpl::hash(hash_algo, &buf[..size]);
             assert_eq!(digest.as_ref().unwrap().as_ref(), expected.as_ref());


### PR DESCRIPTION
Errors are now smaller and local to where they are used. Errors higher up in the
stack implement `From` operations for lower level errors for composition and
tranformation via the `?` operator.

This strategy is more idiomatic rust and matches the techniques used in Hubris.
Furthermore, by removing any strings involved in constructing errors we reduce
text segment size.