### PR TITLE
Abstract crypto code via features and capabilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,20 +2,25 @@
 name = "spdm"
 version = "0.1.0"
 edition = "2018"
-authors = ["Andrew J. Stone <andrew@oxidecomputer.com>"]
 license = "MPL 2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+crypto-ring = ["ring", "webpki", "rand"]
 
 [dependencies]
 bitflags = "1.3"
-ring = "0.16.20"
-webpki = "0.22.0"
+webpki = { version = "0.22.0", optional = true}
+
+[dependencies.ring]
+version = "0.16.20"
+default-features = false
+optional = true
 
 [dependencies.rand]
 version = "0.8"
 default-features = false
 features = [ "getrandom" ]
+optional = true
 
 [dev-dependencies]
 test-utils = { path = "test-utils" }

--- a/README.adoc
+++ b/README.adoc
@@ -276,12 +276,12 @@ https://github.com/oxidecomputer/spdm/blob/bf40def68f149b3f17f25a4f296aaddfb634c
 This template generation is straightforward without the need for a dependency, although it may be safer to use a
 name based generator rather than relying on argument position. 
 
-It should also be mentioned that we plan to drive the requester state
-transitions for the session initialization phase via the capabilities present in
-the configuration. For example, if pre-shared keys are in use via `PSK_CAP`,
-then the states managing PSK related message exchanges will be utilized. In this
-case the mutually exclusive `CERT_CAP` which indicates usage of digests and
-certificates will not have its related states entered or messages exchanges 
+It should also be mentioned that we drive the requester state transitions for
+the session initialization phase via the capabilities present in the
+configuration. For example, if pre-shared keys are in use via `PSK_CAP`, then
+the states managing PSK related message exchanges will be utilized. In this case
+the mutually exclusive `CERT_CAP` which indicates usage of digests and
+certificates will not have its related states entered or messages exchanges
 performed. To be more concrete: If `PSK_CAP` is enabled then the following
 message exchanges will be implemented:
 
@@ -315,6 +315,9 @@ cryptography. Currently all software RSA implementations in rust require
 dynamic allocation, which is not permitted here. This is also fine, because
 really, you shouldn't be using RSA if something else is available.
 
+All crypto is setup to be used behind a feature with a given `provider`. The
+only crypto provider right now is indicated via the cargo feature `crypto-ring`.
+
 Currently, only
 https://github.com/oxidecomputer/spdm/blob/bf40def68f149b3f17f25a4f296aaddfb634c6f3/src/crypto/signing.rs[signing] and 
 https://github.com/oxidecomputer/spdm/blob/bf40def68f149b3f17f25a4f296aaddfb634c6f3/src/crypto/pki.rs[verification]
@@ -322,26 +325,29 @@ based on ECDSA and SHA(3)_XXX
 https://github.com/oxidecomputer/spdm/blob/main/src/crypto/digest.rs[digests] are
 implemented. These implementations are backed by
 https://github.com/briansmith/ring[ring] and
-https://github.com/briansmith/webpki[webpki]. 
+https://github.com/briansmith/webpki[webpki].
 
-While not currently done, we intend to put all crypto implementations behind
-cargo features or the toml based configuration. This will allow utilization of
-HW based implementations when needed. We can perhaps even allow people to opt-in
-to allocation based implementations, although that seems like it may be a bridge
-too far.
+Configured capabilities *must* match whether there is a crypto provider enabled
+or not. If the `crypto-ring` feature is not enabled, no capabilities are allowed
+to be present in the TOML config. Build.rs will error in this case. The default
+configuration though, does not have any capabilities currently set, as we are
+testing bringup on MCUs with custom crypto hardware. This means that using the
+default `spdm-config.toml` only the `VCA` message exchanges will occur.
 
 Another important part of the SPDM protocol is that it allows up to eight slots
-of certificate chains to be used for different purposes. We encode this functionality
-in the
-https://github.com/oxidecomputer/spdm/blob/bf40def68f149b3f17f25a4f296aaddfb634c6f3/src/crypto/slot.rs[FilledSlot] abstraction which describes the algorithms used by the given
-certificate. 
+of certificate chains to be used for different purposes. We encode this
+functionality in the
+https://github.com/oxidecomputer/spdm/blob/bf40def68f149b3f17f25a4f296aaddfb634c6f3/src/crypto/slot.rs[FilledSlot]
+abstraction which describes the algorithms used by the given certificate.
 
-Note since each slot, even if empty,  takes up a memory buffer of
+Note since each slot, even if empty, takes up a memory buffer of
 https://github.com/oxidecomputer/spdm/blob/bf40def68f149b3f17f25a4f296aaddfb634c6f3/config.rs.template#L7-L9[MAX_CERT_CHAIN_SIZE],
 we allow restricting the number of slots available to an implementation when
 more are not needed and memory pressure is significant. This can be done via the
 https://github.com/oxidecomputer/spdm/blob/bf40def68f149b3f17f25a4f296aaddfb634c6f3/config.rs.template#L5[NUM_SLOTS]
 configuration value.
+
+
 
 ==== Measurements
 
@@ -369,3 +375,20 @@ All messages should have at least round-trip serialization tests. Some states
 also have unit tests. An example that steps through a complete happy path of the
 currently implemented protocol for both requester and responder exists in the
 link:tests/protocol.rs[successful_e2e] integration test.
+
+Testing the full e2e code must be done with a crypto provider enabled via
+cargo feature. Currently
+`crypto-ring` is the only provider featue. You can run the full test suite on a
+host OS with the following command.
+
+```
+SPDM_CONFIG=spdm-config-crypto.toml cargo test --features crypto-ring
+```
+
+For platforms where a crypto provider is not available, a subset of tests can be
+run with the following command. This uses the `spdm-config.toml` by default
+which does not currently enable crypto.
+
+```
+cargo test
+```

--- a/spdm-config-crypto.toml
+++ b/spdm-config-crypto.toml
@@ -1,9 +1,6 @@
-# This file contains an example configuration with no crypto provider.
+# This file contains an example configuration.
 version = 0x11
-capabilities = []
-
-# Use this if you have a crypto provider available
-#capabilities = ["CERT_CAP", "CHAL_CAP", "ENCRYPT_CAP",  "MAC_CAP", "MUT_AUTH_CAP", "KEY_EX_CAP", "KEY_UPD_CAP"]
+capabilities = ["CERT_CAP", "CHAL_CAP", "ENCRYPT_CAP",  "MAC_CAP", "MUT_AUTH_CAP", "KEY_EX_CAP", "KEY_UPD_CAP"]
 
 [cert_chains]
 # Tests currently rely on this being greater >= 5

--- a/src/crypto/digest.rs
+++ b/src/crypto/digest.rs
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use core::cmp::PartialEq;
 use core::convert::AsRef;
 
 use crate::msgs::algorithms::BaseHashAlgo;
@@ -10,92 +9,4 @@ use crate::msgs::algorithms::BaseHashAlgo;
 /// Providers implement this trait to provide cryptographic hash support
 pub trait Digest: AsRef<[u8]> {
     fn hash(algorithm: BaseHashAlgo, buf: &[u8]) -> Self;
-}
-
-// TODO: put this behind a feature
-pub type DigestImpl = RingDigest;
-
-/// A Ring based implementation of a Digest
-///
-// TODO: Put this behind a feature
-#[derive(Debug, Clone)]
-pub struct RingDigest {
-    digest: ring::digest::Digest,
-}
-
-impl PartialEq for RingDigest {
-    fn eq(&self, other: &RingDigest) -> bool {
-        self.as_ref() == other.as_ref()
-    }
-}
-
-impl Eq for RingDigest {}
-
-impl Digest for RingDigest {
-    fn hash(algorithm: BaseHashAlgo, buf: &[u8]) -> Self {
-        let algo = match algorithm {
-            BaseHashAlgo::SHA_256 => &ring::digest::SHA256,
-            BaseHashAlgo::SHA_384 => &ring::digest::SHA384,
-            BaseHashAlgo::SHA_512 => &ring::digest::SHA512,
-            _ => unimplemented!(),
-        };
-        RingDigest { digest: ring::digest::digest(algo, buf) }
-    }
-}
-
-impl AsRef<[u8]> for RingDigest {
-    fn as_ref(&self) -> &[u8] {
-        self.digest.as_ref()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use ring::test::from_hex;
-
-    #[test]
-    // Expected hashes from openssl output on cli
-    // `echo test | openssl dgst -sha256`
-    fn ring_digest_sha256() {
-        let expected = from_hex(
-            "f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2",
-        )
-        .unwrap();
-
-        let actual = RingDigest::hash(BaseHashAlgo::SHA_256, b"test\n");
-        assert_eq!(&expected, actual.as_ref());
-    }
-
-    #[test]
-    // Expected hashes from openssl output on cli
-    // `echo test | openssl dgst -sha384`
-    fn ring_digest_sha384() {
-        let expected = from_hex(
-            "109bb6b5b6d5547c1ce03c7a8bd7d8f80c1cb0957f50c4f7fda04692079917e4f9cad52b878f3d8234e1a170b154b72d"
-        )
-        .unwrap();
-
-        let actual = RingDigest::hash(BaseHashAlgo::SHA_384, b"test\n");
-        assert_eq!(&expected, actual.as_ref());
-    }
-
-    #[test]
-    // Expected hashes from openssl output on cli
-    // `echo test | openssl dgst -sha512`
-    fn ring_digest_sha512() {
-        let expected = from_hex(
-            "0e3e75234abc68f4378a86b3f4b32a198ba301845b0cd6e50106e874345700cc6663a86c1ea125dc5e92be17c98f9a0f85ca9d5f595db2012f7cc3571945c123"
-        )
-        .unwrap();
-
-        let actual = RingDigest::hash(BaseHashAlgo::SHA_512, b"test\n");
-        assert_eq!(&expected, actual.as_ref());
-    }
-
-    #[test]
-    #[should_panic]
-    fn ring_digest_unsupported() {
-        RingDigest::hash(BaseHashAlgo::SHA3_256, b"test\n");
-    }
 }

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -17,6 +17,8 @@ mod no_crypto_defaults;
 pub use no_crypto_defaults::new_end_entity_cert;
 #[cfg(not(feature = "crypto"))]
 pub use no_crypto_defaults::DigestImpl;
+#[cfg(not(feature = "crypto"))]
+pub use no_crypto_defaults::FakeSigner;
 
 #[cfg(feature = "crypto-ring")]
 pub mod ring;

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -4,21 +4,27 @@
 
 //! The crypto module provides the traits that the rest of the SPDM code relies
 //! on to implement the cryptographic parts of the protocol.
-//!
-//! An initial implementation based on <https://github.com/briansmith/ring>
-//! is provided for digests and signing. An initial implementation of
-//! certificate validation and signature verification is provided by
-//! [webpki](https://github.com/briansmith/webpki), itself backed by `ring`.
-//!
-//! It is expected that all implementations provided by the spdm crate will be
-//! behind features, although this is not done yet. A given deployment of a
-//! system using SPDM is likely only to support a few of these implementations,
-//! and just as likely to implement a few of its own to support specific
-//! hardware.
+
 pub mod digest;
+mod nonce;
 pub mod pki;
 pub mod signing;
 mod slot;
 
+#[cfg(not(feature = "crypto"))]
+mod no_crypto_defaults;
+#[cfg(not(feature = "crypto"))]
+pub use no_crypto_defaults::new_end_entity_cert;
+#[cfg(not(feature = "crypto"))]
+pub use no_crypto_defaults::DigestImpl;
+
+#[cfg(feature = "crypto-ring")]
+pub mod ring;
+#[cfg(feature = "crypto-ring")]
+pub use self::ring::digest::DigestImpl;
+#[cfg(feature = "crypto-ring")]
+pub use self::ring::pki::new_end_entity_cert;
+
+pub use nonce::Nonce;
 pub use signing::Signer;
 pub use slot::FilledSlot;

--- a/src/crypto/no_crypto_defaults.rs
+++ b/src/crypto/no_crypto_defaults.rs
@@ -1,0 +1,66 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! This module provides unimplemented, dummy instances of types and functions
+//! for use of this library without the "crypto" feature enabled.
+//!
+//! This mechanism allows the higher level code to be compiled without littering
+//! conditional compilation directives across the requester and responder.
+//!
+//! Mechanisms higher up the stack are used to ensure that these default
+//! implementations are never actually called. If any of these functions or
+//! methods panics then we have a bug up the stack where states are being
+//! transitioned to where the capabilities are not enabled.
+
+use crate::msgs::algorithms::{BaseAsymAlgo, BaseHashAlgo};
+
+use super::{
+    digest::Digest,
+    pki::{self, EndEntityCert},
+};
+
+use core::marker::PhantomData;
+
+pub type DigestImpl = FakeDigest;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FakeDigest;
+
+impl Digest for FakeDigest {
+    fn hash(_: BaseHashAlgo, _: &[u8]) -> Self {
+        unimplemented!();
+    }
+}
+
+impl AsRef<[u8]> for FakeDigest {
+    fn as_ref(&self) -> &[u8] {
+        unimplemented!();
+    }
+}
+
+pub fn new_end_entity_cert<'a>(
+    _: &'a [u8],
+) -> Result<impl EndEntityCert<'a>, pki::Error> {
+    Ok(FakeEndEntityCert { phantom: PhantomData })
+}
+
+pub struct FakeEndEntityCert<'a> {
+    phantom: PhantomData<&'a [u8]>,
+}
+
+impl<'a> EndEntityCert<'a> for FakeEndEntityCert<'a> {
+    fn verify_signature(&self, _: BaseAsymAlgo, _: &[u8], _: &[u8]) -> bool {
+        unimplemented!();
+    }
+
+    fn verify_chain_of_trust(
+        &self,
+        _: BaseAsymAlgo,
+        _: &[&[u8]],
+        _: &[u8],
+        _: u64,
+    ) -> Result<(), pki::Error> {
+        unimplemented!();
+    }
+}

--- a/src/crypto/no_crypto_defaults.rs
+++ b/src/crypto/no_crypto_defaults.rs
@@ -18,6 +18,7 @@ use crate::msgs::algorithms::{BaseAsymAlgo, BaseHashAlgo};
 use super::{
     digest::Digest,
     pki::{self, EndEntityCert},
+    signing::{self, Signature, Signer},
 };
 
 use core::marker::PhantomData;
@@ -42,7 +43,9 @@ impl AsRef<[u8]> for FakeDigest {
 pub fn new_end_entity_cert<'a>(
     _: &'a [u8],
 ) -> Result<impl EndEntityCert<'a>, pki::Error> {
-    Ok(FakeEndEntityCert { phantom: PhantomData })
+    Ok(FakeEndEntityCert {
+        phantom: PhantomData,
+    })
 }
 
 pub struct FakeEndEntityCert<'a> {
@@ -61,6 +64,24 @@ impl<'a> EndEntityCert<'a> for FakeEndEntityCert<'a> {
         _: &[u8],
         _: u64,
     ) -> Result<(), pki::Error> {
+        unimplemented!();
+    }
+}
+
+pub struct FakeSigner;
+
+pub struct FakeSignature;
+
+impl Signature for FakeSignature {}
+impl AsRef<[u8]> for FakeSignature {
+    fn as_ref(&self) -> &[u8] {
+        unimplemented!()
+    }
+}
+
+impl Signer for FakeSigner {
+    type Signature = FakeSignature;
+    fn sign(&self, msg: &[u8]) -> Result<Self::Signature, signing::Error> {
         unimplemented!();
     }
 }

--- a/src/crypto/nonce.rs
+++ b/src/crypto/nonce.rs
@@ -1,0 +1,74 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#[cfg(feature = "rand")]
+use rand::{rngs::OsRng, RngCore};
+
+use crate::msgs::encoding::{ReadError, Reader};
+
+/// A unique random value used for cryptographic purposes
+///
+/// Nonces are only capable of being generated if the underlying platform
+/// supports `rand`
+#[cfg(feature = "rand")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Nonce([u8; 32]);
+
+#[cfg(feature = "rand")]
+impl Nonce {
+    pub fn new() -> Nonce {
+        let mut nonce = [0u8; 32];
+        OsRng.fill_bytes(&mut nonce);
+        Nonce(nonce)
+    }
+
+    pub fn read(r: &mut Reader) -> Result<Nonce, ReadError> {
+        let mut nonce = [0u8; 32];
+        r.get_slice(32, &mut nonce)?;
+        Ok(Nonce(nonce))
+    }
+}
+
+#[cfg(not(feature = "rand"))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Nonce([u8; 0]);
+
+#[cfg(not(feature = "rand"))]
+impl Nonce {
+    pub fn new() -> Nonce {
+        Nonce([0u8; 0])
+    }
+
+    pub fn read(_: &mut Reader) -> Result<Nonce, ReadError> {
+        Ok(Nonce([0u8; 0]))
+    }
+}
+
+impl AsRef<[u8]> for Nonce {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl AsMut<[u8]> for Nonce {
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    impl Nonce {
+        #[cfg(feature = "rand")]
+        pub fn new_with_magic(magic: u8) -> Nonce {
+            Nonce([magic; 32])
+        }
+
+        #[cfg(not(feature = "rand"))]
+        pub fn new_with_magic(magic: u8) -> Nonce {
+            Nonce([magic; 0])
+        }
+    }
+}

--- a/src/crypto/provider.rs
+++ b/src/crypto/provider.rs
@@ -1,0 +1,30 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! A provider implements cryptographic mechanisms required by the SPDM protocol.
+//! Each mechanism supports some number of different algorithms.
+//!
+//! An example of a mechanism is a *digest*, which may support SHA_256 and SHA_512
+//! algorithms. A provider of a digest mechanism would be something like `ring`
+//! or `RustCrypto`.
+
+use super::digest::Digest;
+use super::pki::EndEntityCert;
+use super::signing::{Signature, Signer};
+
+pub trait CryptoProvider {
+    type Digest: Digest;
+    type Pki: PkiProvider;
+    type Signature: SignatureProvider;
+}
+
+pub trait PkiProvider {
+    type EndEntityCert: EndEntityCert;
+}
+
+// TODO: Maybe add `Verifier`. Do we want to only allow verification via pki?
+pub trait SignatureProvider {
+    type Signature: Signature;
+    type Signer: Signer;
+}

--- a/src/crypto/ring/digest.rs
+++ b/src/crypto/ring/digest.rs
@@ -1,0 +1,95 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use core::cmp::PartialEq;
+
+use crate::crypto::digest::Digest;
+use crate::msgs::algorithms::BaseHashAlgo;
+
+// TODO: Should this even exist? Should a single crypto provider be used for all
+// mechanisms? Should we allow more than one provider per crypto mechanism?
+pub type DigestImpl = RingDigest;
+
+/// A Ring based implementation of a Digest
+#[derive(Debug, Clone)]
+pub struct RingDigest {
+    digest: ring::digest::Digest,
+}
+
+impl PartialEq for RingDigest {
+    fn eq(&self, other: &RingDigest) -> bool {
+        self.as_ref() == other.as_ref()
+    }
+}
+
+impl Eq for RingDigest {}
+
+impl Digest for RingDigest {
+    fn hash(algorithm: BaseHashAlgo, buf: &[u8]) -> Self {
+        let algo = match algorithm {
+            BaseHashAlgo::SHA_256 => &ring::digest::SHA256,
+            BaseHashAlgo::SHA_384 => &ring::digest::SHA384,
+            BaseHashAlgo::SHA_512 => &ring::digest::SHA512,
+            _ => unimplemented!(),
+        };
+        RingDigest { digest: ring::digest::digest(algo, buf) }
+    }
+}
+
+impl AsRef<[u8]> for RingDigest {
+    fn as_ref(&self) -> &[u8] {
+        self.digest.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ring::test::from_hex;
+
+    #[test]
+    // Expected hashes from openssl output on cli
+    // `echo test | openssl dgst -sha256`
+    fn ring_digest_sha256() {
+        let expected = from_hex(
+            "f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2",
+        )
+        .unwrap();
+
+        let actual = RingDigest::hash(BaseHashAlgo::SHA_256, b"test\n");
+        assert_eq!(&expected, actual.as_ref());
+    }
+
+    #[test]
+    // Expected hashes from openssl output on cli
+    // `echo test | openssl dgst -sha384`
+    fn ring_digest_sha384() {
+        let expected = from_hex(
+            "109bb6b5b6d5547c1ce03c7a8bd7d8f80c1cb0957f50c4f7fda04692079917e4f9cad52b878f3d8234e1a170b154b72d"
+        )
+        .unwrap();
+
+        let actual = RingDigest::hash(BaseHashAlgo::SHA_384, b"test\n");
+        assert_eq!(&expected, actual.as_ref());
+    }
+
+    #[test]
+    // Expected hashes from openssl output on cli
+    // `echo test | openssl dgst -sha512`
+    fn ring_digest_sha512() {
+        let expected = from_hex(
+            "0e3e75234abc68f4378a86b3f4b32a198ba301845b0cd6e50106e874345700cc6663a86c1ea125dc5e92be17c98f9a0f85ca9d5f595db2012f7cc3571945c123"
+        )
+        .unwrap();
+
+        let actual = RingDigest::hash(BaseHashAlgo::SHA_512, b"test\n");
+        assert_eq!(&expected, actual.as_ref());
+    }
+
+    #[test]
+    #[should_panic]
+    fn ring_digest_unsupported() {
+        RingDigest::hash(BaseHashAlgo::SHA3_256, b"test\n");
+    }
+}

--- a/src/crypto/ring/mod.rs
+++ b/src/crypto/ring/mod.rs
@@ -1,0 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Crypto backed by <https://github.com/briansmith/ring>
+
+pub mod digest;
+pub mod pki;
+pub mod signing;

--- a/src/crypto/ring/pki.rs
+++ b/src/crypto/ring/pki.rs
@@ -1,0 +1,89 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use core::convert::TryFrom;
+
+use crate::msgs::algorithms::BaseAsymAlgo;
+
+use super::super::pki::{bin_to_der, max_encoded_size, EndEntityCert, Error};
+
+pub fn new_end_entity_cert<'a>(
+    leaf_cert: &'a [u8],
+) -> Result<impl EndEntityCert<'a>, Error> {
+    WebpkiEndEntityCert::new(leaf_cert)
+}
+
+// We don't support any RSA algorithms via webpki because they are based on
+// Ring which requires using alloc;
+//
+// Note that we map a specific curve to a single hash function, which
+// matches the spirit of TLS 1.3 and also fits the signature sizes expected
+// in the `BaseAsymAlgo` description of the `NEGOTIATE_ALGORITHMS` message.
+fn spdm_to_webpki(algo: BaseAsymAlgo) -> &'static webpki::SignatureAlgorithm {
+    match algo {
+        BaseAsymAlgo::ECDSA_ECC_NIST_P256 => &webpki::ECDSA_P256_SHA256,
+        BaseAsymAlgo::ECDSA_ECC_NIST_P384 => &webpki::ECDSA_P384_SHA384,
+        _ => unimplemented!(),
+    }
+}
+
+/// webpki based implementaion of `EndEntityCert`
+///
+/// TODO: put behind a feature flag
+pub struct WebpkiEndEntityCert<'a> {
+    cert: webpki::EndEntityCert<'a>,
+}
+
+impl<'a> WebpkiEndEntityCert<'a> {
+    pub fn new(cert: &'a [u8]) -> Result<WebpkiEndEntityCert<'a>, Error> {
+        let cert = webpki::EndEntityCert::try_from(cert)
+            .map_err(|_| Error::InvalidCert)?;
+        Ok(WebpkiEndEntityCert { cert })
+    }
+}
+
+impl<'a> EndEntityCert<'a> for WebpkiEndEntityCert<'a> {
+    fn verify_signature(
+        &self,
+        algorithm: BaseAsymAlgo,
+        msg: &[u8],
+        signature: &[u8],
+    ) -> bool {
+        let algo = spdm_to_webpki(algorithm);
+        let mut der = [0u8; max_encoded_size()];
+        let size = bin_to_der(signature, &mut der[..]);
+        self.cert.verify_signature(algo, msg, &der[..size]).is_ok()
+    }
+
+    fn verify_chain_of_trust(
+        &self,
+        algorithm: BaseAsymAlgo,
+        intermediate_certs: &[&[u8]],
+        root_cert: &[u8],
+        seconds_since_unix_epoch: u64,
+    ) -> Result<(), Error> {
+        let trust_anchors = [webpki::TrustAnchor::try_from_cert_der(root_cert)
+            .map_err(|_| Error::InvalidCert)?; 1];
+
+        // TODO: Does it matter if we use server or client here?
+        let server_trust_anchors =
+            webpki::TlsServerTrustAnchors(&trust_anchors);
+
+        let time = webpki::Time::from_seconds_since_unix_epoch(
+            seconds_since_unix_epoch,
+        );
+
+        let algo = spdm_to_webpki(algorithm);
+
+        // TODO: Map error types for more info?
+        self.cert
+            .verify_is_valid_tls_server_cert(
+                &[algo],
+                &server_trust_anchors,
+                intermediate_certs,
+                time,
+            )
+            .map_err(|_| Error::ValidationFailed)
+    }
+}

--- a/src/crypto/ring/signing.rs
+++ b/src/crypto/ring/signing.rs
@@ -1,0 +1,100 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use ring::signature::{
+    EcdsaKeyPair, EcdsaSigningAlgorithm, ECDSA_P256_SHA256_FIXED_SIGNING,
+    ECDSA_P384_SHA384_FIXED_SIGNING,
+};
+
+use ring::rand::SystemRandom;
+
+use super::super::signing::{Error, Signature, Signer};
+use crate::msgs::algorithms::BaseAsymAlgo;
+
+// Convert a SPDM algorithmn to a Ring algorithm
+//
+// TODO: Put behind feature
+fn spdm_to_ring(algorithm: BaseAsymAlgo) -> &'static EcdsaSigningAlgorithm {
+    match algorithm {
+        BaseAsymAlgo::ECDSA_ECC_NIST_P256 => &ECDSA_P256_SHA256_FIXED_SIGNING,
+        BaseAsymAlgo::ECDSA_ECC_NIST_P384 => &ECDSA_P384_SHA384_FIXED_SIGNING,
+        _ => unimplemented!(),
+    }
+}
+
+/// Take a private key in PKCS#8 v1 format and create a new signer. The signer
+/// key must correspond to the given algorithm.
+///
+/// This is explicitly not part of a trait, as a HW module would not take a
+/// private key. The application level software should call this function.
+///
+/// TODO: Hide this behind a feature
+pub fn new_signer(
+    algorithm: BaseAsymAlgo,
+    private_key: &[u8],
+) -> Result<RingSigner, Error> {
+    let algorithm = spdm_to_ring(algorithm);
+    RingSigner::new(algorithm, private_key)
+}
+
+/// A Signer backed by ring
+///
+/// TODO: Put behind a feature
+pub struct RingSigner {
+    key_pair: EcdsaKeyPair,
+    rng: SystemRandom,
+}
+
+impl RingSigner {
+    pub fn new(
+        algorithm: &'static EcdsaSigningAlgorithm,
+        private_key: &[u8],
+    ) -> Result<RingSigner, Error> {
+        let key_pair = EcdsaKeyPair::from_pkcs8(algorithm, private_key)
+            .map_err(|_| Error {})?;
+        Ok(RingSigner { key_pair, rng: SystemRandom::new() })
+    }
+}
+
+impl Signature for ring::signature::Signature {}
+
+impl Signer for RingSigner {
+    type Signature = ring::signature::Signature;
+
+    fn sign(&self, msg: &[u8]) -> Result<Self::Signature, Error> {
+        self.key_pair.sign(&self.rng, msg).map_err(|_| Error {})
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::pki::EndEntityCert;
+    use crate::crypto::ring::pki::new_end_entity_cert;
+    use test_utils::certs::*;
+
+    // Sign a message using a private key and verify it using a certificate
+    #[test]
+    fn sign_and_verify() {
+        let algorithm = BaseAsymAlgo::ECDSA_ECC_NIST_P256;
+        let leaf_params = cert_params_ecdsa_p256_sha256(false, "Leaf");
+        let cert = rcgen::Certificate::from_params(leaf_params).unwrap();
+
+        let private_key = cert.serialize_private_key_der();
+        let signer = new_signer(algorithm, &private_key).unwrap();
+
+        let leaf_der = cert.serialize_der().unwrap();
+        let end_entity_cert = new_end_entity_cert(&leaf_der).unwrap();
+
+        let msg = b"hello, hello";
+
+        let signature = signer.sign(msg).unwrap();
+
+        assert!(end_entity_cert.verify_signature(
+            algorithm,
+            msg,
+            signature.as_ref()
+        ));
+    }
+}

--- a/src/crypto/signing.rs
+++ b/src/crypto/signing.rs
@@ -4,18 +4,7 @@
 
 use core::convert::AsRef;
 
-use ring::signature::{
-    EcdsaKeyPair, EcdsaSigningAlgorithm, ECDSA_P256_SHA256_FIXED_SIGNING,
-    ECDSA_P384_SHA384_FIXED_SIGNING,
-};
-
-use ring::rand::SystemRandom;
-
-use crate::msgs::algorithms::BaseAsymAlgo;
-
 // Opaque error type
-//
-//
 #[derive(Debug)]
 pub struct Error {}
 
@@ -27,90 +16,4 @@ pub trait Signer {
     type Signature: Signature;
 
     fn sign(&self, msg: &[u8]) -> Result<Self::Signature, Error>;
-}
-
-// Convert a SPDM algorithmn to a Ring algorithm
-//
-// TODO: Put behind feature
-fn spdm_to_ring(algorithm: BaseAsymAlgo) -> &'static EcdsaSigningAlgorithm {
-    match algorithm {
-        BaseAsymAlgo::ECDSA_ECC_NIST_P256 => &ECDSA_P256_SHA256_FIXED_SIGNING,
-        BaseAsymAlgo::ECDSA_ECC_NIST_P384 => &ECDSA_P384_SHA384_FIXED_SIGNING,
-        _ => unimplemented!(),
-    }
-}
-
-/// Take a private key in PKCS#8 v1 format and create a new signer. The signer
-/// key must correspond to the given algorithm.
-///
-/// This is explicitly not part of a trait, as a HW module would not take a
-/// private key. The application level software should call this function.
-///
-/// TODO: Hide this behind a feature
-pub fn new_signer(
-    algorithm: BaseAsymAlgo,
-    private_key: &[u8],
-) -> Result<RingSigner, Error> {
-    let algorithm = spdm_to_ring(algorithm);
-    RingSigner::new(algorithm, private_key)
-}
-
-/// A Signer backed by ring
-///
-/// TODO: Put behind a feature
-pub struct RingSigner {
-    key_pair: EcdsaKeyPair,
-    rng: SystemRandom,
-}
-
-impl RingSigner {
-    pub fn new(
-        algorithm: &'static EcdsaSigningAlgorithm,
-        private_key: &[u8],
-    ) -> Result<RingSigner, Error> {
-        let key_pair = EcdsaKeyPair::from_pkcs8(algorithm, private_key)
-            .map_err(|_| Error {})?;
-        Ok(RingSigner { key_pair, rng: SystemRandom::new() })
-    }
-}
-
-impl Signature for ring::signature::Signature {}
-
-impl Signer for RingSigner {
-    type Signature = ring::signature::Signature;
-
-    fn sign(&self, msg: &[u8]) -> Result<Self::Signature, Error> {
-        self.key_pair.sign(&self.rng, msg).map_err(|_| Error {})
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::crypto::pki::{new_end_entity_cert, EndEntityCert};
-    use test_utils::certs::*;
-
-    // Sign a message using a private key and verify it using a certificate
-    #[test]
-    fn sign_and_verify() {
-        let algorithm = BaseAsymAlgo::ECDSA_ECC_NIST_P256;
-        let leaf_params = cert_params_ecdsa_p256_sha256(false, "Leaf");
-        let cert = rcgen::Certificate::from_params(leaf_params).unwrap();
-
-        let private_key = cert.serialize_private_key_der();
-        let signer = new_signer(algorithm, &private_key).unwrap();
-
-        let leaf_der = cert.serialize_der().unwrap();
-        let end_entity_cert = new_end_entity_cert(&leaf_der).unwrap();
-
-        let msg = b"hello, hello";
-
-        let signature = signer.sign(msg).unwrap();
-
-        assert!(end_entity_cert.verify_signature(
-            algorithm,
-            msg,
-            signature.as_ref()
-        ));
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,4 +13,6 @@ pub mod responder;
 pub mod msgs;
 pub(crate) mod transcript;
 
+pub use requester::{RequesterError, RequesterInit, RequesterSession};
+pub use responder::{Responder, ResponderError};
 pub use transcript::Transcript;

--- a/src/msgs/certificates.rs
+++ b/src/msgs/certificates.rs
@@ -335,7 +335,10 @@ impl<'a> CertificateChain<'a> {
 mod tests {
     use core::convert::TryFrom;
     use rcgen;
+
+    #[cfg(feature = "webpki")]
     use std::time::SystemTime;
+    #[cfg(feature = "webpki")]
     use webpki;
 
     use super::super::HEADER_SIZE;
@@ -437,6 +440,7 @@ mod tests {
     // and verified by `webpki`. This is a useful test for correctness, since
     // both crates are written by independent authors. It serves mostly as an
     // example of how to use webpki with DER encoded cert chains.
+    #[cfg(feature = "webpki")]
     #[test]
     fn example_webpki_verify_cert_chain() {
         let root_params = cert_params_ecdsa_p256_sha256(true, "Root");

--- a/src/msgs/challenge.rs
+++ b/src/msgs/challenge.rs
@@ -5,9 +5,11 @@
 use core::cmp::PartialEq;
 use core::convert::{TryFrom, TryInto};
 
+use crate::crypto::Nonce;
+
 use super::common::{
-    DigestBuf, DigestSize, Nonce, OpaqueData, ParseOpaqueDataError,
-    SignatureBuf, SignatureSize, WriteOpaqueElementError,
+    DigestBuf, DigestSize, OpaqueData, ParseOpaqueDataError, SignatureBuf,
+    SignatureSize, WriteOpaqueElementError,
 };
 use super::encoding::{BufferFullError, ReadError, Reader, Writer};
 use super::Msg;

--- a/src/msgs/common.rs
+++ b/src/msgs/common.rs
@@ -8,7 +8,6 @@ use super::{BufferFullError, ReadError, Reader, Writer};
 use crate::config;
 
 use core::convert::{From, TryFrom, TryInto};
-use rand::{rngs::OsRng, RngCore};
 
 #[derive(Debug, PartialEq)]
 pub enum ParseOpaqueDataError {
@@ -494,36 +493,6 @@ impl PartialEq for SignatureBuf {
 
 impl Eq for SignatureBuf {}
 
-/// A unique random value used for cryptographic purposes
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Nonce([u8; 32]);
-
-impl Nonce {
-    pub fn new() -> Nonce {
-        let mut nonce = [0u8; 32];
-        OsRng.fill_bytes(&mut nonce);
-        Nonce(nonce)
-    }
-
-    pub fn read(r: &mut Reader) -> Result<Nonce, ReadError> {
-        let mut nonce = [0u8; 32];
-        r.get_slice(32, &mut nonce)?;
-        Ok(Nonce(nonce))
-    }
-}
-
-impl AsRef<[u8]> for Nonce {
-    fn as_ref(&self) -> &[u8] {
-        &self.0
-    }
-}
-
-impl AsMut<[u8]> for Nonce {
-    fn as_mut(&mut self) -> &mut [u8] {
-        &mut self.0
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -539,12 +508,6 @@ mod tests {
     impl SignatureBuf {
         pub fn new_with_magic(size: SignatureSize, magic: u8) -> SignatureBuf {
             SignatureBuf { size, buf: [magic; config::MAX_SIGNATURE_SIZE] }
-        }
-    }
-
-    impl Nonce {
-        pub fn new_with_magic(magic: u8) -> Nonce {
-            Nonce([magic; 32])
         }
     }
 

--- a/src/requester/algorithms.rs
+++ b/src/requester/algorithms.rs
@@ -4,7 +4,7 @@
 
 use core::convert::From;
 
-use super::{capabilities, expect, id_auth, RequesterError};
+use super::{capabilities, expect, RequesterError};
 use crate::config;
 use crate::msgs::algorithms::*;
 use crate::msgs::capabilities::{ReqFlags, RspFlags};
@@ -55,17 +55,20 @@ impl State {
     }
 
     /// Only `Algorithms` messsages are acceptable here.
+    ///
+    /// The resulting state is based on capabilities and algorithm
+    /// version. We let the caller handle the transition.
     pub fn handle_msg(
-        mut self,
+        &mut self,
         buf: &[u8],
         transcript: &mut Transcript,
-    ) -> Result<id_auth::State, RequesterError> {
+    ) -> Result<(), RequesterError> {
         expect::<Algorithms>(buf)?;
         let algorithms = Algorithms::parse_body(&buf[HEADER_SIZE..])?;
         self.ensure_valid_algorithms_selected(&algorithms)?;
         self.algorithms = Some(algorithms);
         transcript.extend(buf)?;
-        Ok(self.into())
+        Ok(())
     }
 
     // Make sure that any algorithms chosen by the responder correspond to

--- a/src/requester/id_auth.rs
+++ b/src/requester/id_auth.rs
@@ -4,7 +4,7 @@
 
 use core::convert::From;
 
-use super::{algorithms, challenge, expect, RequesterError};
+use super::{algorithms, expect, RequesterError};
 use crate::config::{MAX_CERT_CHAIN_SIZE, NUM_SLOTS};
 use crate::msgs::capabilities::{ReqFlags, RspFlags};
 use crate::msgs::{
@@ -117,14 +117,14 @@ impl State {
 
     // Handle a CERTFICATE msg.
     pub fn handle_certificate(
-        mut self,
+        &mut self,
         buf: &[u8],
         transcript: &mut Transcript,
-    ) -> Result<challenge::State, RequesterError> {
+    ) -> Result<(), RequesterError> {
         expect::<Certificate>(buf)?;
         let cert = Certificate::parse_body(&buf[HEADER_SIZE..])?;
         self.cert_chain = Some(cert);
         transcript.extend(buf)?;
-        Ok(self.into())
+        Ok(())
     }
 }

--- a/src/responder.rs
+++ b/src/responder.rs
@@ -201,6 +201,14 @@ impl<'a, S: Signer> Responder<'a, S> {
     pub fn slots(&self) -> &[Option<FilledSlot<'a, S>>; config::NUM_SLOTS] {
         &self.slots
     }
+
+    /// Go back to the initial `version::State`.
+    ///
+    /// This also resets the transcript
+    pub fn reset(&mut self) {
+        self.transcript.clear();
+        self.state = Some(version::State {}.into());
+    }
 }
 
 /// Go back to the Version state and process a GetVersion message.

--- a/src/responder.rs
+++ b/src/responder.rs
@@ -47,6 +47,7 @@ use core::convert::From;
 /// enum, `AllStates`. We then provide a wrapper `Responder` API around
 /// `AllStates` that a user can consume without having to know all the internal
 /// details of the SPDM protocol.
+#[derive(Debug, PartialEq)]
 pub enum AllStates {
     // A special state that indicates the responder has terminated and the
     // transport should close its "connection".

--- a/src/responder/challenge.rs
+++ b/src/responder/challenge.rs
@@ -7,13 +7,10 @@ use core::convert::From;
 use super::{expect, id_auth, AllStates, ResponderError};
 
 use crate::config::{MAX_CERT_CHAIN_SIZE, NUM_SLOTS};
-use crate::crypto::{
-    digest::{Digest, DigestImpl},
-    FilledSlot, Signer,
-};
+use crate::crypto::{digest::Digest, DigestImpl, FilledSlot, Nonce, Signer};
 use crate::msgs::{
     capabilities::{ReqFlags, RspFlags},
-    common::{DigestBuf, Nonce, SignatureBuf},
+    common::{DigestBuf, SignatureBuf},
     encoding::Writer,
     Algorithms, Challenge, ChallengeAuth, Msg, OpaqueData, HEADER_SIZE,
 };

--- a/src/responder/id_auth.rs
+++ b/src/responder/id_auth.rs
@@ -6,7 +6,7 @@ use core::convert::TryFrom;
 
 use super::{algorithms, challenge, expect, AllStates, ResponderError};
 use crate::config::{MAX_CERT_CHAIN_SIZE, NUM_SLOTS};
-use crate::crypto::digest::{Digest, DigestImpl};
+use crate::crypto::{digest::Digest, DigestImpl};
 use crate::msgs::{
     capabilities::{ReqFlags, RspFlags},
     common::DigestBuf,

--- a/src/responder/no_crypto_states.rs
+++ b/src/responder/no_crypto_states.rs
@@ -1,0 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! This module contains the minimal implementation of states that are not in
+//! use when the "crypto" feature  is not enabled. The purpose of this is to
+//! minimize the amount of conditional compilation required in the rest of the code.

--- a/src/responder/no_crypto_states.rs
+++ b/src/responder/no_crypto_states.rs
@@ -1,7 +1,0 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
-//! This module contains the minimal implementation of states that are not in
-//! use when the "crypto" feature  is not enabled. The purpose of this is to
-//! minimize the amount of conditional compilation required in the rest of the code.

--- a/src/responder/version.rs
+++ b/src/responder/version.rs
@@ -6,6 +6,7 @@ use super::{capabilities, AllStates, ResponderError};
 use crate::msgs::{GetVersion, Msg, Version, HEADER_SIZE};
 use crate::Transcript;
 
+#[derive(Debug, PartialEq)]
 pub struct State {}
 
 impl State {

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -2,11 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+#![cfg(feature = "crypto-ring")]
+
 use spdm::config::{MAX_CERT_CHAIN_SIZE, NUM_SLOTS};
 use spdm::crypto::{
-    digest::{Digest, DigestImpl},
-    signing::{new_signer, RingSigner},
-    FilledSlot, Signer,
+    digest::Digest,
+    ring::signing::{new_signer, RingSigner},
+    DigestImpl, FilledSlot, Signer,
 };
 use spdm::msgs::algorithms::*;
 use spdm::msgs::{

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -30,7 +30,10 @@ pub struct Data {
 
 impl Data {
     pub fn new() -> Data {
-        Data { req_buf: [0u8; BUF_SIZE], rsp_buf: [0u8; BUF_SIZE] }
+        Data {
+            req_buf: [0u8; BUF_SIZE],
+            rsp_buf: [0u8; BUF_SIZE],
+        }
     }
 }
 
@@ -69,7 +72,9 @@ impl Certs {
     pub fn cert_chain<'a>(&'a self) -> CertificateChain<'a> {
         let mut chain =
             CertificateChain::new(self.root_hash.as_ref(), &self.leaf_der);
-        chain.append_intermediate_cert(&self.intermediate_der).unwrap();
+        chain
+            .append_intermediate_cert(&self.intermediate_der)
+            .unwrap();
         chain
     }
 }


### PR DESCRIPTION
If a crypto provider is not configured via feature (currently only
`crypto-ring`), all crypto related states in the protocol will be skipped by the
requester. If crypto capabilities are enabled in the config.toml file, but a
provider feature is not given, build.rs will panic.

An attempt was made to minimize the amount of conditional compilation. Almost
all of the conditions exist in the crypto modules themselves with default
implementations that will panic if run by higher level code. This is safe for
two reasons:

 1. States that use crypto will be skipped if the capabilities are not enabled.
 2. Build.rs will panic if a crypto provider is not enabled, but capabilities
 that use crypto are enabled.

The `Nonce` code was also moved out of `src/msgs/common.rs` and into
`src/crypto/common.rs` to keep the message code mostly free of conditional
compilation.

Also, reliance on ring was removed for certificate chain parsing of DER
encoded chains. This was easy as it only required adding consts for two DER tag
bytes.

Lastly, a crypto provider trait was added, but is not yet used. We plan to
transition the existing crypto traits to the de-facto standard rust-crypto
traits in a follow up request, and we will almost certainly use the provider at
that point. That will remove the need for use of silly type aliases like
`DigestImpl` that are behind features.